### PR TITLE
chore: install vue toastification

### DIFF
--- a/finance-app/frontend/package-lock.json
+++ b/finance-app/frontend/package-lock.json
@@ -12,7 +12,7 @@
         "core-js": "^3.6.5",
         "vue": "^3.0.0",
         "vue-router": "^4.0.0",
-        "vue-toastification": "^2.0.0-rc.5",
+        "vue-toastification": "2.0.0-rc.5",
         "vuex": "^4.0.0"
       },
       "devDependencies": {

--- a/finance-app/frontend/package.json
+++ b/finance-app/frontend/package.json
@@ -13,7 +13,7 @@
     "vue": "^3.0.0",
     "vue-router": "^4.0.0",
     "vuex": "^4.0.0",
-    "vue-toastification": "^2.0.0-rc.5"
+    "vue-toastification": "2.0.0-rc.5"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "~4.5.0",

--- a/finance-app/frontend/src/assets/css/tailwind.css
+++ b/finance-app/frontend/src/assets/css/tailwind.css
@@ -1,0 +1,1 @@
+/* TailwindCSS base imports placeholder. Add actual Tailwind directives if needed. */


### PR DESCRIPTION
## Summary
- update the frontend dependency list to include vue-toastification 2.0.0-rc.5
- add a placeholder Tailwind CSS entry file so the existing import resolves

## Testing
- npm install
- CI=1 npm run build *(fails: relative component imports referenced from src/store/index.js are missing in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68dfd62b9b6c832292e9f776926d4ab3