### PR TITLE
feat: apply glassmorphism redesign across frontend

### DIFF
--- a/finance-app/frontend/src/App.vue
+++ b/finance-app/frontend/src/App.vue
@@ -1,8 +1,18 @@
 <template>
-  <div class="min-h-screen bg-neutral-100 dark:bg-neutral-900">
+  <div class="app-shell">
+    <div class="pointer-events-none absolute inset-0 -z-10">
+      <div class="h-full w-full bg-gradient-to-br from-primary/10 via-white/40 to-secondary/10 dark:from-neutral-900/90 dark:via-neutral-950/70 dark:to-neutral-900/80"></div>
+      <div class="absolute left-1/2 top-12 h-72 w-72 -translate-x-1/2 rounded-full bg-primary/20 blur-3xl dark:bg-primary/15"></div>
+      <div class="absolute bottom-0 right-12 h-64 w-64 rounded-full bg-secondary/20 blur-3xl dark:bg-secondary/15"></div>
+    </div>
+
     <header-component v-if="isAuthenticated" />
-    <main class="container mx-auto px-4 py-6">
-      <router-view />
+    <main class="page-container">
+      <router-view v-slot="{ Component }">
+        <transition name="page" mode="out-in">
+          <component :is="Component" />
+        </transition>
+      </router-view>
     </main>
     <footer-component v-if="isAuthenticated" />
   </div>

--- a/finance-app/frontend/src/assets/css/tailwind.css
+++ b/finance-app/frontend/src/assets/css/tailwind.css
@@ -1,1 +1,425 @@
-/* TailwindCSS base imports placeholder. Add actual Tailwind directives if needed. */
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Roboto+Mono:wght@400;500&display=swap');
+
+:root {
+  --color-primary: #0078ff;
+  --color-primary-light: #4da6ff;
+  --color-primary-dark: #0057b8;
+
+  --color-secondary: #6a3d7c;
+  --color-secondary-light: #8c54a1;
+  --color-secondary-dark: #4a2957;
+
+  --color-success: #38a169;
+  --color-success-light: #48bb78;
+  --color-success-dark: #2f855a;
+
+  --color-danger: #e53e3e;
+  --color-danger-light: #f56565;
+  --color-danger-dark: #c53030;
+
+  --color-warning: #ed8936;
+  --color-warning-light: #f6ad55;
+  --color-warning-dark: #dd6b20;
+
+  --color-info: #4299e1;
+  --color-info-light: #63b3ed;
+  --color-info-dark: #3182ce;
+}
+
+body {
+  @apply bg-neutral-100 text-neutral-900 font-sans antialiased;
+  background-image: radial-gradient(circle at 20% 20%, rgba(0, 120, 255, 0.08), transparent 45%),
+    radial-gradient(circle at 80% 0%, rgba(74, 41, 87, 0.08), transparent 50%);
+}
+
+.dark body {
+  @apply bg-neutral-900 text-neutral-100;
+  background-image: radial-gradient(circle at 20% 20%, rgba(0, 120, 255, 0.12), transparent 45%),
+    radial-gradient(circle at 80% 0%, rgba(140, 84, 161, 0.12), transparent 55%);
+}
+
+.app-shell {
+  @apply min-h-screen relative overflow-hidden;
+}
+
+.app-shell::before,
+.app-shell::after {
+  content: '';
+  position: absolute;
+  width: 520px;
+  height: 520px;
+  border-radius: 9999px;
+  filter: blur(90px);
+  opacity: 0.4;
+  z-index: 0;
+  transition: opacity 0.3s ease;
+}
+
+.app-shell::before {
+  top: -200px;
+  left: -120px;
+  background: linear-gradient(135deg, rgba(0, 120, 255, 0.55), rgba(140, 84, 161, 0.45));
+}
+
+.app-shell::after {
+  bottom: -220px;
+  right: -150px;
+  background: linear-gradient(135deg, rgba(72, 187, 120, 0.55), rgba(66, 153, 225, 0.45));
+}
+
+.dark .app-shell::before {
+  opacity: 0.65;
+  background: linear-gradient(135deg, rgba(0, 120, 255, 0.35), rgba(140, 84, 161, 0.35));
+}
+
+.dark .app-shell::after {
+  opacity: 0.65;
+  background: linear-gradient(135deg, rgba(72, 187, 120, 0.35), rgba(66, 153, 225, 0.35));
+}
+
+.page-container {
+  @apply relative z-10 mx-auto w-full max-w-7xl px-4 py-10 sm:px-6 lg:px-8 lg:py-14;
+}
+
+.page-card {
+  @apply rounded-3xl border border-white/60 bg-white/85 p-8 shadow-xl backdrop-blur-xl;
+}
+
+.dark .page-card {
+  @apply border-neutral-700/60 bg-neutral-900/80;
+}
+
+.section-card {
+  @apply rounded-2xl border border-white/40 bg-white/80 p-6 shadow-lg backdrop-blur-lg transition-transform duration-300 ease-out hover:-translate-y-1 hover:shadow-2xl;
+}
+
+.dark .section-card {
+  @apply border-neutral-700/60 bg-neutral-900/70;
+}
+
+.stat-card {
+  @apply rounded-2xl border border-white/30 bg-white/75 p-5 text-left shadow-md backdrop-blur-lg;
+}
+
+.dark .stat-card {
+  @apply border-neutral-700/60 bg-neutral-900/70;
+}
+
+.glass-panel {
+  @apply border border-white/50 bg-white/70 shadow-xl backdrop-blur-xl;
+}
+
+.dark .glass-panel {
+  @apply border-neutral-700/60 bg-neutral-900/80;
+}
+
+.auth-shell {
+  @apply min-h-screen relative overflow-hidden flex items-center justify-center px-4 py-16 sm:px-6 lg:px-8;
+  background: radial-gradient(circle at 20% 20%, rgba(0, 120, 255, 0.18), transparent 50%),
+    radial-gradient(circle at 80% 0%, rgba(106, 61, 124, 0.18), transparent 55%),
+    linear-gradient(135deg, #eff6ff 0%, #f8fafc 35%, #f1f5f9 70%, #eef2ff 100%);
+}
+
+.dark .auth-shell {
+  background: radial-gradient(circle at 20% 20%, rgba(0, 120, 255, 0.22), transparent 55%),
+    radial-gradient(circle at 75% -5%, rgba(106, 61, 124, 0.24), transparent 55%),
+    linear-gradient(135deg, #0f172a 0%, #111827 40%, #020617 100%);
+}
+
+.auth-card {
+  @apply relative w-full max-w-lg overflow-hidden rounded-3xl border border-white/60 bg-white/85 p-10 shadow-2xl backdrop-blur-2xl;
+}
+
+.dark .auth-card {
+  @apply border-neutral-700/60 bg-neutral-900/85;
+}
+
+.auth-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(0, 120, 255, 0.08), rgba(140, 84, 161, 0.08));
+}
+
+.dark .auth-card::after {
+  background: linear-gradient(135deg, rgba(77, 166, 255, 0.08), rgba(140, 84, 161, 0.1));
+}
+
+.card {
+  transition: all 0.3s ease-in-out;
+}
+
+.card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 20px 45px -20px rgba(0, 0, 0, 0.25);
+}
+
+.dark .card:hover {
+  box-shadow: 0 20px 45px -20px rgba(0, 0, 0, 0.7);
+}
+
+.chart-container {
+  width: 100%;
+  height: 400px;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0.5;
+  }
+}
+
+.animate-pulse {
+  animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+
+.tooltip {
+  position: relative;
+  display: inline-block;
+}
+
+.tooltip .tooltip-text {
+  visibility: hidden;
+  width: 200px;
+  background-color: var(--color-bg-secondary, #111827);
+  color: var(--color-text-primary, #f9fafb);
+  text-align: center;
+  border-radius: 0.75rem;
+  padding: 0.75rem;
+  position: absolute;
+  z-index: 10;
+  bottom: 125%;
+  left: 50%;
+  margin-left: -100px;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  box-shadow: 0 10px 25px -15px rgba(0, 0, 0, 0.35);
+}
+
+.tooltip:hover .tooltip-text {
+  visibility: visible;
+  opacity: 1;
+}
+
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: rgba(148, 163, 184, 0.25);
+}
+
+.dark ::-webkit-scrollbar-track {
+  background: rgba(55, 65, 81, 0.65);
+}
+
+::-webkit-scrollbar-thumb {
+  background: rgba(100, 116, 139, 0.55);
+  border-radius: 9999px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: rgba(71, 85, 105, 0.8);
+}
+
+.dark ::-webkit-scrollbar-thumb {
+  background: rgba(148, 163, 184, 0.55);
+}
+
+.dark ::-webkit-scrollbar-thumb:hover {
+  background: rgba(226, 232, 240, 0.65);
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(0, 120, 255, 0.2);
+}
+
+.dark input:focus,
+.dark select:focus,
+.dark textarea:focus {
+  box-shadow: 0 0 0 3px rgba(77, 166, 255, 0.2);
+}
+
+button {
+  transition: all 0.2s ease-in-out;
+}
+
+button:hover {
+  transform: translateY(-1px);
+}
+
+button:active {
+  transform: translateY(1px);
+}
+
+.page-enter-active,
+.page-leave-active {
+  transition: opacity 0.3s, transform 0.3s;
+}
+
+.page-enter-from,
+.page-leave-to {
+  opacity: 0;
+  transform: translateY(10px);
+}
+
+.Vue-Toastification__toast {
+  border-radius: 1rem !important;
+  font-family: 'Inter', sans-serif !important;
+}
+
+.Vue-Toastification__toast--success {
+  background-color: var(--color-success) !important;
+}
+
+.Vue-Toastification__toast--error {
+  background-color: var(--color-danger) !important;
+}
+
+.Vue-Toastification__toast--warning {
+  background-color: var(--color-warning) !important;
+}
+
+.Vue-Toastification__toast--info {
+  background-color: var(--color-info) !important;
+}
+
+.tv-lightweight-charts {
+  font-family: 'Inter', sans-serif !important;
+}
+
+table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+}
+
+th {
+  font-weight: 600;
+  text-align: left;
+}
+
+tr {
+  transition: background-color 0.2s ease-in-out;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.loader {
+  border: 3px solid rgba(0, 0, 0, 0.1);
+  border-radius: 50%;
+  border-top: 3px solid var(--color-primary);
+  width: 24px;
+  height: 24px;
+  animation: spin 1s linear infinite;
+}
+
+.dark .loader {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-top-color: var(--color-primary);
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+.modal-backdrop {
+  background-color: rgba(15, 23, 42, 0.55);
+  backdrop-filter: blur(3px);
+}
+
+.modal-content {
+  border-radius: 1.25rem;
+  box-shadow: 0 25px 60px -30px rgba(15, 23, 42, 0.4);
+}
+
+.dark .modal-content {
+  box-shadow: 0 25px 60px -30px rgba(0, 0, 0, 0.65);
+}
+
+.info-tooltip {
+  position: relative;
+  display: inline-block;
+  cursor: help;
+}
+
+.info-tooltip .info-tooltip-text {
+  visibility: hidden;
+  width: 220px;
+  background-color: #1f2937;
+  color: #f9fafb;
+  text-align: left;
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  position: absolute;
+  z-index: 15;
+  bottom: 125%;
+  left: 50%;
+  margin-left: -110px;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  font-size: 0.75rem;
+  line-height: 1.25rem;
+  box-shadow: 0 20px 40px -25px rgba(15, 23, 42, 0.55);
+}
+
+.info-tooltip:hover .info-tooltip-text {
+  visibility: visible;
+  opacity: 1;
+}
+
+.help-bubble {
+  position: fixed;
+  bottom: 32px;
+  right: 32px;
+  background: linear-gradient(135deg, #0078ff 0%, #6a3d7c 100%);
+  color: white;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  box-shadow: 0 20px 35px -25px rgba(0, 120, 255, 0.6);
+  transition: all 0.3s ease-in-out;
+}
+
+.help-bubble:hover {
+  transform: translateY(-4px) scale(1.05);
+}

--- a/finance-app/frontend/src/components/layout/FooterComponent.vue
+++ b/finance-app/frontend/src/components/layout/FooterComponent.vue
@@ -1,13 +1,21 @@
 <template>
-  <div class="bg-neutral-100 dark:bg-neutral-900 py-4">
-    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-      <div class="text-center">
-        <p class="text-sm text-neutral-500 dark:text-neutral-400">
-          © {{ currentYear }} Finance Analysis Platform. Tous droits réservés.
-        </p>
+  <footer class="relative z-10 pb-10">
+    <div class="mx-auto w-[calc(100%-2rem)] max-w-7xl">
+      <div class="glass-panel rounded-3xl px-6 py-5 sm:px-10">
+        <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p class="text-sm font-medium uppercase tracking-[0.2em] text-neutral-400 dark:text-neutral-500">Finance Analysis</p>
+            <p class="mt-1 text-sm text-neutral-600 dark:text-neutral-300">
+              Plateforme d'analyse financière moderne et intuitive.
+            </p>
+          </div>
+          <div class="text-sm text-neutral-500 dark:text-neutral-400">
+            © {{ currentYear }} Finance Analysis Platform. Tous droits réservés.
+          </div>
+        </div>
       </div>
     </div>
-  </div>
+  </footer>
 </template>
 
 <script>

--- a/finance-app/frontend/src/components/layout/HeaderComponent.vue
+++ b/finance-app/frontend/src/components/layout/HeaderComponent.vue
@@ -1,217 +1,185 @@
 <template>
-  <div class="flex flex-col h-screen">
-    <nav class="bg-white dark:bg-neutral-800 shadow-md">
-      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div class="flex justify-between h-16">
-          <div class="flex">
-            <div class="flex-shrink-0 flex items-center">
-              <router-link to="/dashboard" class="text-xl font-bold text-primary">Finance Analysis</router-link>
-            </div>
-            <div class="hidden sm:ml-6 sm:flex sm:space-x-8">
-              <router-link 
-                to="/dashboard" 
-                class="border-transparent text-neutral-500 dark:text-neutral-300 hover:border-primary hover:text-primary dark:hover:text-primary inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium"
-                :class="{ 'border-primary text-primary': isActive('dashboard') }"
-              >
-                Tableau de bord
-              </router-link>
-              <router-link 
-                to="/analysis/technical" 
-                class="border-transparent text-neutral-500 dark:text-neutral-300 hover:border-primary hover:text-primary dark:hover:text-primary inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium"
-                :class="{ 'border-primary text-primary': isActive('analysis') }"
-              >
-                Analyse
-              </router-link>
-              <router-link 
-                to="/portfolio" 
-                class="border-transparent text-neutral-500 dark:text-neutral-300 hover:border-primary hover:text-primary dark:hover:text-primary inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium"
-                :class="{ 'border-primary text-primary': isActive('portfolio') }"
-              >
-                Portefeuille
-              </router-link>
-              <router-link 
-                to="/alerts" 
-                class="border-transparent text-neutral-500 dark:text-neutral-300 hover:border-primary hover:text-primary dark:hover:text-primary inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium"
-                :class="{ 'border-primary text-primary': isActive('alerts') }"
-              >
-                Alertes
-              </router-link>
-              <router-link 
-                to="/calendar" 
-                class="border-transparent text-neutral-500 dark:text-neutral-300 hover:border-primary hover:text-primary dark:hover:text-primary inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium"
-                :class="{ 'border-primary text-primary': isActive('calendar') }"
-              >
-                Calendrier
-              </router-link>
-            </div>
-          </div>
-          <div class="hidden sm:ml-6 sm:flex sm:items-center">
-            <button 
-              @click="toggleDarkMode" 
-              class="p-1 rounded-full text-neutral-500 dark:text-neutral-300 hover:text-primary dark:hover:text-primary focus:outline-none"
-            >
-              <span class="sr-only">Changer de thème</span>
-              <svg v-if="isDarkMode" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+  <header class="relative z-20">
+    <nav class="glass-panel mx-auto mt-6 w-[calc(100%-2rem)] max-w-7xl rounded-3xl px-4 py-3 sm:px-6 lg:px-8">
+      <div class="flex h-16 items-center justify-between">
+        <div class="flex items-center gap-6">
+          <router-link to="/dashboard" class="flex items-center text-xl font-semibold tracking-tight text-neutral-900 transition hover:text-primary dark:text-white">
+            <span class="mr-2 inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-primary/15 text-primary">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-5 w-5">
+                <path d="M12 3a9 9 0 00-9 9v5.5A3.5 3.5 0 006.5 21h11a3.5 3.5 0 003.5-3.5V12a9 9 0 00-9-9zm0 2a7 7 0 017 7v5.5c0 .828-.672 1.5-1.5 1.5h-11A1.5 1.5 0 015 17.5V12a7 7 0 017-7zm0 4a3 3 0 00-3 3v2a3 3 0 006 0v-2a3 3 0 00-3-3zm0 2a1 1 0 011 1v2a1 1 0 11-2 0v-2a1 1 0 011-1z" />
               </svg>
-              <svg v-else xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
-              </svg>
-            </button>
+            </span>
+            Finance Analysis
+          </router-link>
 
-            <div class="ml-3 relative">
-              <div>
-                <button 
-                  @click="toggleUserMenu" 
-                  class="bg-white dark:bg-neutral-800 rounded-full flex text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
-                >
-                  <span class="sr-only">Ouvrir le menu utilisateur</span>
-                  <div class="h-8 w-8 rounded-full bg-primary text-white flex items-center justify-center">
-                    {{ userInitials }}
-                  </div>
-                </button>
-              </div>
-              <div 
-                v-if="userMenuOpen" 
-                class="origin-top-right absolute right-0 mt-2 w-48 rounded-md shadow-lg py-1 bg-white dark:bg-neutral-800 ring-1 ring-black ring-opacity-5 focus:outline-none z-10"
-              >
-                <router-link 
-                  to="/settings" 
-                  class="block px-4 py-2 text-sm text-neutral-700 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-700"
-                  @click="userMenuOpen = false"
-                >
-                  Paramètres
-                </router-link>
-                <a 
-                  href="#" 
-                  @click.prevent="logout" 
-                  class="block px-4 py-2 text-sm text-neutral-700 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-700"
-                >
-                  Déconnexion
-                </a>
-              </div>
-            </div>
-          </div>
-          <div class="-mr-2 flex items-center sm:hidden">
-            <button 
-              @click="toggleMobileMenu" 
-              class="inline-flex items-center justify-center p-2 rounded-md text-neutral-400 hover:text-neutral-500 hover:bg-neutral-100 dark:hover:bg-neutral-700 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-primary"
+          <div class="hidden items-center gap-1 rounded-full bg-white/60 px-1 py-1 text-sm font-medium dark:bg-neutral-800/80 md:flex">
+            <router-link
+              v-for="item in navigation"
+              :key="item.route"
+              :to="item.to"
+              class="inline-flex items-center rounded-full px-4 py-2 transition"
+              :class="isActive(item.route)
+                ? 'bg-primary text-white shadow-sm'
+                : 'text-neutral-500 hover:text-neutral-900 hover:bg-white dark:text-neutral-300 dark:hover:text-white dark:hover:bg-neutral-700/70'"
             >
-              <span class="sr-only">Ouvrir le menu principal</span>
-              <svg 
-                :class="{ 'hidden': mobileMenuOpen, 'block': !mobileMenuOpen }" 
-                class="h-6 w-6" 
-                xmlns="http://www.w3.org/2000/svg" 
-                fill="none" 
-                viewBox="0 0 24 24" 
-                stroke="currentColor" 
-                aria-hidden="true"
-              >
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-              </svg>
-              <svg 
-                :class="{ 'block': mobileMenuOpen, 'hidden': !mobileMenuOpen }" 
-                class="h-6 w-6" 
-                xmlns="http://www.w3.org/2000/svg" 
-                fill="none" 
-                viewBox="0 0 24 24" 
-                stroke="currentColor" 
-                aria-hidden="true"
-              >
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+              {{ item.label }}
+            </router-link>
+          </div>
+        </div>
+
+        <div class="hidden items-center gap-4 md:flex">
+          <button
+            @click="toggleDarkMode"
+            class="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/60 bg-white/80 text-neutral-500 transition hover:text-primary dark:border-neutral-700/70 dark:bg-neutral-800/80 dark:text-neutral-300 dark:hover:text-primary"
+          >
+            <span class="sr-only">Changer de thème</span>
+            <svg v-if="isDarkMode" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+            </svg>
+            <svg v-else xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+            </svg>
+          </button>
+
+          <div class="relative">
+            <button
+              @click="toggleUserMenu"
+              class="flex items-center gap-3 rounded-full border border-white/60 bg-white/80 py-1 pl-1 pr-4 text-sm font-medium text-neutral-700 shadow-sm transition hover:text-primary dark:border-neutral-700/70 dark:bg-neutral-800/80 dark:text-neutral-200"
+            >
+              <span class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-primary text-white">
+                {{ userInitials }}
+              </span>
+              <span class="hidden lg:block">{{ user.full_name || 'Utilisateur' }}</span>
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
               </svg>
             </button>
+            <div
+              v-if="userMenuOpen"
+              class="glass-panel absolute right-0 mt-3 w-56 overflow-hidden rounded-2xl p-2 text-sm shadow-2xl"
+            >
+              <div class="px-3 py-2 text-xs uppercase tracking-wide text-neutral-400 dark:text-neutral-500">
+                Accès rapide
+              </div>
+              <router-link
+                to="/settings"
+                class="flex items-center gap-3 rounded-xl px-3 py-2 text-neutral-600 transition hover:bg-white/70 hover:text-neutral-900 dark:text-neutral-300 dark:hover:bg-neutral-700/80 dark:hover:text-white"
+                @click="userMenuOpen = false"
+              >
+                <span class="inline-flex h-8 w-8 items-center justify-center rounded-xl bg-primary/15 text-primary">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 11V7a4 4 0 118 0v4m-2 4h-4m0 0v4m0-4h4m-4 0H7" />
+                  </svg>
+                </span>
+                Paramètres
+              </router-link>
+              <button
+                @click.prevent="logout"
+                class="flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left text-neutral-600 transition hover:bg-danger/10 hover:text-danger dark:text-neutral-300 dark:hover:bg-danger/15 dark:hover:text-danger"
+              >
+                <span class="inline-flex h-8 w-8 items-center justify-center rounded-xl bg-danger/10 text-danger">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7" />
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 8v8" />
+                  </svg>
+                </span>
+                Déconnexion
+              </button>
+            </div>
           </div>
+        </div>
+
+        <div class="flex items-center gap-3 md:hidden">
+          <button
+            @click="toggleDarkMode"
+            class="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/60 bg-white/80 text-neutral-500 transition hover:text-primary dark:border-neutral-700/70 dark:bg-neutral-800/80 dark:text-neutral-300 dark:hover:text-primary"
+          >
+            <span class="sr-only">Changer de thème</span>
+            <svg v-if="isDarkMode" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+            </svg>
+            <svg v-else xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+            </svg>
+          </button>
+          <button
+            @click="toggleMobileMenu"
+            class="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/60 bg-white/80 text-neutral-500 transition hover:text-primary dark:border-neutral-700/70 dark:bg-neutral-800/80 dark:text-neutral-300 dark:hover:text-primary"
+          >
+            <span class="sr-only">Ouvrir le menu principal</span>
+            <svg
+              :class="{ hidden: mobileMenuOpen, block: !mobileMenuOpen }"
+              class="h-5 w-5"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+            </svg>
+            <svg
+              :class="{ block: mobileMenuOpen, hidden: !mobileMenuOpen }"
+              class="h-5 w-5"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
         </div>
       </div>
 
-      <div :class="{ 'block': mobileMenuOpen, 'hidden': !mobileMenuOpen }" class="sm:hidden">
-        <div class="pt-2 pb-3 space-y-1">
-          <router-link 
-            to="/dashboard" 
-            class="block pl-3 pr-4 py-2 border-l-4 text-base font-medium"
-            :class="isActive('dashboard') ? 'border-primary text-primary bg-primary-50 dark:bg-primary-900 dark:bg-opacity-10' : 'border-transparent text-neutral-500 dark:text-neutral-300 hover:bg-neutral-50 dark:hover:bg-neutral-700 hover:border-neutral-300 dark:hover:border-neutral-600'"
+      <div
+        :class="{ 'max-h-[460px] opacity-100': mobileMenuOpen, 'max-h-0 opacity-0': !mobileMenuOpen }"
+        class="md:hidden overflow-hidden transition-all duration-300 ease-in-out"
+      >
+        <div class="mt-4 space-y-2 rounded-2xl bg-white/80 p-3 shadow-inner dark:bg-neutral-900/80">
+          <router-link
+            v-for="item in navigation"
+            :key="item.route"
+            :to="item.to"
+            class="block rounded-xl px-4 py-3 text-sm font-medium transition"
+            :class="isActive(item.route)
+              ? 'bg-primary/10 text-primary'
+              : 'text-neutral-600 hover:bg-white hover:text-neutral-900 dark:text-neutral-300 dark:hover:bg-neutral-800'"
             @click="mobileMenuOpen = false"
           >
-            Tableau de bord
+            {{ item.label }}
           </router-link>
-          <router-link 
-            to="/analysis/technical" 
-            class="block pl-3 pr-4 py-2 border-l-4 text-base font-medium"
-            :class="isActive('analysis') ? 'border-primary text-primary bg-primary-50 dark:bg-primary-900 dark:bg-opacity-10' : 'border-transparent text-neutral-500 dark:text-neutral-300 hover:bg-neutral-50 dark:hover:bg-neutral-700 hover:border-neutral-300 dark:hover:border-neutral-600'"
-            @click="mobileMenuOpen = false"
-          >
-            Analyse
-          </router-link>
-          <router-link 
-            to="/portfolio" 
-            class="block pl-3 pr-4 py-2 border-l-4 text-base font-medium"
-            :class="isActive('portfolio') ? 'border-primary text-primary bg-primary-50 dark:bg-primary-900 dark:bg-opacity-10' : 'border-transparent text-neutral-500 dark:text-neutral-300 hover:bg-neutral-50 dark:hover:bg-neutral-700 hover:border-neutral-300 dark:hover:border-neutral-600'"
-            @click="mobileMenuOpen = false"
-          >
-            Portefeuille
-          </router-link>
-          <router-link 
-            to="/alerts" 
-            class="block pl-3 pr-4 py-2 border-l-4 text-base font-medium"
-            :class="isActive('alerts') ? 'border-primary text-primary bg-primary-50 dark:bg-primary-900 dark:bg-opacity-10' : 'border-transparent text-neutral-500 dark:text-neutral-300 hover:bg-neutral-50 dark:hover:bg-neutral-700 hover:border-neutral-300 dark:hover:border-neutral-600'"
-            @click="mobileMenuOpen = false"
-          >
-            Alertes
-          </router-link>
-          <router-link 
-            to="/calendar" 
-            class="block pl-3 pr-4 py-2 border-l-4 text-base font-medium"
-            :class="isActive('calendar') ? 'border-primary text-primary bg-primary-50 dark:bg-primary-900 dark:bg-opacity-10' : 'border-transparent text-neutral-500 dark:text-neutral-300 hover:bg-neutral-50 dark:hover:bg-neutral-700 hover:border-neutral-300 dark:hover:border-neutral-600'"
-            @click="mobileMenuOpen = false"
-          >
-            Calendrier
-          </router-link>
-        </div>
-        <div class="pt-4 pb-3 border-t border-neutral-200 dark:border-neutral-700">
-          <div class="flex items-center px-4">
-            <div class="flex-shrink-0">
-              <div class="h-10 w-10 rounded-full bg-primary text-white flex items-center justify-center">
+          <div class="rounded-2xl bg-white/70 p-4 text-sm dark:bg-neutral-900/70">
+            <div class="flex items-center gap-3">
+              <div class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-primary text-white">
                 {{ userInitials }}
               </div>
+              <div class="text-sm">
+                <p class="font-semibold text-neutral-900 dark:text-white">{{ user.full_name }}</p>
+                <p class="text-neutral-500 dark:text-neutral-400">{{ user.email }}</p>
+              </div>
             </div>
-            <div class="ml-3">
-              <div class="text-base font-medium text-neutral-800 dark:text-white">{{ user.full_name }}</div>
-              <div class="text-sm font-medium text-neutral-500 dark:text-neutral-400">{{ user.email }}</div>
+            <div class="mt-4 grid gap-2">
+              <router-link
+                to="/settings"
+                class="rounded-xl px-3 py-2 text-neutral-600 transition hover:bg-white hover:text-neutral-900 dark:text-neutral-300 dark:hover:bg-neutral-800"
+                @click="mobileMenuOpen = false"
+              >
+                Paramètres
+              </router-link>
+              <button
+                @click.prevent="logout"
+                class="rounded-xl px-3 py-2 text-left text-neutral-600 transition hover:bg-danger/10 hover:text-danger dark:text-neutral-300 dark:hover:bg-danger/15 dark:hover:text-danger"
+              >
+                Déconnexion
+              </button>
             </div>
-            <button 
-              @click="toggleDarkMode" 
-              class="ml-auto p-1 rounded-full text-neutral-400 hover:text-neutral-500 dark:hover:text-neutral-300 focus:outline-none"
-            >
-              <span class="sr-only">Changer de thème</span>
-              <svg v-if="isDarkMode" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
-              </svg>
-              <svg v-else xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
-              </svg>
-            </button>
-          </div>
-          <div class="mt-3 space-y-1">
-            <router-link 
-              to="/settings" 
-              class="block px-4 py-2 text-base font-medium text-neutral-500 dark:text-neutral-300 hover:text-neutral-800 dark:hover:text-white hover:bg-neutral-100 dark:hover:bg-neutral-700"
-              @click="mobileMenuOpen = false"
-            >
-              Paramètres
-            </router-link>
-            <a 
-              href="#" 
-              @click.prevent="logout" 
-              class="block px-4 py-2 text-base font-medium text-neutral-500 dark:text-neutral-300 hover:text-neutral-800 dark:hover:text-white hover:bg-neutral-100 dark:hover:bg-neutral-700"
-            >
-              Déconnexion
-            </a>
           </div>
         </div>
       </div>
     </nav>
-  </div>
+  </header>
 </template>
 
 <script>
@@ -230,6 +198,14 @@ export default {
 
     const mobileMenuOpen = ref(false)
     const userMenuOpen = ref(false)
+
+    const navigation = [
+      { label: 'Tableau de bord', route: 'dashboard', to: '/dashboard' },
+      { label: 'Analyse', route: 'analysis', to: '/analysis/technical' },
+      { label: 'Portefeuille', route: 'portfolio', to: '/portfolio' },
+      { label: 'Alertes', route: 'alerts', to: '/alerts' },
+      { label: 'Calendrier', route: 'calendar', to: '/calendar' }
+    ]
 
     const user = computed(() => store.getters['auth/getUser'] || {})
     const isDarkMode = computed(() => store.getters.isDarkMode)
@@ -287,6 +263,7 @@ export default {
       user,
       isDarkMode,
       userInitials,
+      navigation,
       toggleMobileMenu,
       toggleUserMenu,
       toggleDarkMode,

--- a/finance-app/frontend/src/components/layout/PageHeader.vue
+++ b/finance-app/frontend/src/components/layout/PageHeader.vue
@@ -1,0 +1,38 @@
+<template>
+  <div class="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+    <div>
+      <p v-if="eyebrow" class="text-xs font-semibold uppercase tracking-[0.4em] text-primary/70 dark:text-primary/60">
+        {{ eyebrow }}
+      </p>
+      <h1 class="text-3xl font-semibold tracking-tight text-neutral-900 dark:text-white sm:text-4xl">
+        {{ title }}
+      </h1>
+      <p v-if="description" class="mt-3 max-w-2xl text-base text-neutral-600 dark:text-neutral-300">
+        {{ description }}
+      </p>
+    </div>
+    <div class="flex flex-wrap items-center gap-3">
+      <slot name="actions" />
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'PageHeader',
+  props: {
+    title: {
+      type: String,
+      required: true
+    },
+    description: {
+      type: String,
+      default: ''
+    },
+    eyebrow: {
+      type: String,
+      default: ''
+    }
+  }
+}
+</script>

--- a/finance-app/frontend/src/views/Alerts.vue
+++ b/finance-app/frontend/src/views/Alerts.vue
@@ -1,80 +1,87 @@
 <template>
-  <div class="bg-white dark:bg-neutral-800 shadow rounded-lg p-6">
-    <div class="flex flex-col md:flex-row md:items-center md:justify-between mb-6">
-      <h1 class="text-2xl font-bold text-neutral-900 dark:text-white">Alertes</h1>
-      
-      <router-link 
-        to="/alerts/create"
-        class="mt-4 md:mt-0 inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-primary hover:bg-primary-dark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
-      >
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
-        </svg>
-        Créer une alerte
-      </router-link>
-    </div>
+  <div class="page-card space-y-10">
+    <page-header
+      eyebrow="Surveillance"
+      title="Alertes intelligentes"
+      description="Configurez des notifications précises et multicanaux pour suivre vos actifs en temps réel."
+    >
+      <template #actions>
+        <router-link
+          to="/alerts/create"
+          class="inline-flex items-center gap-2 rounded-full bg-primary px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-primary/20 transition hover:bg-primary-dark"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+          </svg>
+          Nouvelle alerte
+        </router-link>
+      </template>
+    </page-header>
 
-    <!-- Liste des alertes -->
-    <div v-if="alerts.length > 0" class="mb-8">
+    <div v-if="alerts.length > 0" class="section-card overflow-hidden">
       <div class="overflow-x-auto">
-        <table class="min-w-full divide-y divide-neutral-200 dark:divide-neutral-600">
-          <thead>
+        <table class="min-w-full divide-y divide-white/40 dark:divide-neutral-700/60">
+          <thead class="bg-white/70 backdrop-blur dark:bg-neutral-900/70">
             <tr>
-              <th class="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">Actif</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">Condition</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">Valeur</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">Statut</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">Notifications</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">Actions</th>
+              <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-neutral-500 dark:text-neutral-400">Actif</th>
+              <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-neutral-500 dark:text-neutral-400">Condition</th>
+              <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-neutral-500 dark:text-neutral-400">Valeur</th>
+              <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-neutral-500 dark:text-neutral-400">Statut</th>
+              <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-neutral-500 dark:text-neutral-400">Notifications</th>
+              <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-neutral-500 dark:text-neutral-400">Actions</th>
             </tr>
           </thead>
-          <tbody class="divide-y divide-neutral-200 dark:divide-neutral-600">
-            <tr v-for="alert in alerts" :key="alert.id" class="hover:bg-neutral-50 dark:hover:bg-neutral-700">
-              <td class="px-6 py-4 whitespace-nowrap">
-                <div class="flex items-center">
-                  <div class="text-sm font-medium text-neutral-900 dark:text-white">{{ alert.asset_symbol }}</div>
-                  <div class="text-sm text-neutral-500 dark:text-neutral-400 ml-2">{{ alert.asset_name }}</div>
+          <tbody class="divide-y divide-white/30 dark:divide-neutral-800/60">
+            <tr v-for="alert in alerts" :key="alert.id" class="bg-white/60 transition hover:bg-white/90 dark:bg-neutral-900/60 dark:hover:bg-neutral-900/80">
+              <td class="px-6 py-4">
+                <div class="flex items-center gap-3">
+                  <div class="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+                    {{ alert.asset_symbol.substring(0, 3).toUpperCase() }}
+                  </div>
+                  <div>
+                    <p class="text-sm font-semibold text-neutral-900 dark:text-white">{{ alert.asset_symbol }}</p>
+                    <p class="text-xs text-neutral-500 dark:text-neutral-400">{{ alert.asset_name }}</p>
+                  </div>
                 </div>
               </td>
-              <td class="px-6 py-4 whitespace-nowrap">
-                <div class="text-sm text-neutral-900 dark:text-white">{{ formatCondition(alert.condition_type) }}</div>
+              <td class="px-6 py-4 text-sm text-neutral-900 dark:text-white">
+                {{ formatCondition(alert.condition_type) }}
               </td>
-              <td class="px-6 py-4 whitespace-nowrap">
-                <div class="text-sm text-neutral-900 dark:text-white">{{ formatPrice(alert.target_value) }}</div>
+              <td class="px-6 py-4 text-sm text-neutral-900 dark:text-white">
+                {{ formatPrice(alert.target_value) }}
               </td>
-              <td class="px-6 py-4 whitespace-nowrap">
+              <td class="px-6 py-4">
                 <span :class="{
-                  'px-2 py-1 text-xs font-medium rounded-full': true,
-                  'bg-success-light text-success': alert.is_active && !alert.last_triggered,
-                  'bg-warning-light text-warning': alert.is_active && alert.last_triggered,
-                  'bg-neutral-200 dark:bg-neutral-600 text-neutral-700 dark:text-neutral-300': !alert.is_active
+                  'badge bg-success/15 text-success': alert.is_active && !alert.last_triggered,
+                  'badge bg-warning/15 text-warning': alert.is_active && alert.last_triggered,
+                  'badge bg-neutral-200 text-neutral-600 dark:bg-neutral-700 dark:text-neutral-300': !alert.is_active
                 }">
                   {{ getAlertStatus(alert) }}
                 </span>
               </td>
-              <td class="px-6 py-4 whitespace-nowrap">
-                <div class="flex space-x-2">
-                  <span v-if="alert.notify_email" class="text-neutral-500 dark:text-neutral-400" title="Email">
-                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <td class="px-6 py-4">
+                <div class="flex items-center gap-3 text-neutral-500 dark:text-neutral-400">
+                  <span v-if="alert.notify_email" class="rounded-full bg-white/60 p-2 shadow-inner dark:bg-neutral-800/80" title="Email">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
                     </svg>
                   </span>
-                  <span v-if="alert.notify_telegram" class="text-neutral-500 dark:text-neutral-400" title="Telegram">
-                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 24 24" fill="currentColor">
+                  <span v-if="alert.notify_telegram" class="rounded-full bg-white/60 p-2 shadow-inner dark:bg-neutral-800/80" title="Telegram">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="currentColor">
                       <path d="M12 0C5.373 0 0 5.373 0 12s5.373 12 12 12 12-5.373 12-12S18.627 0 12 0zm5.562 8.248l-1.97 9.269c-.145.658-.537.818-1.084.508l-3-2.21-1.446 1.394c-.14.18-.357.295-.6.295-.002 0-.003 0-.005 0l.213-3.054 5.56-5.022c.24-.213-.054-.334-.373-.121l-6.869 4.326-2.96-.924c-.64-.203-.654-.64.135-.954l11.566-4.458c.538-.196 1.006.128.832.952z"/>
                     </svg>
                   </span>
-                  <span v-if="alert.notify_whatsapp" class="text-neutral-500 dark:text-neutral-400" title="WhatsApp">
-                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 24 24" fill="currentColor">
+                  <span v-if="alert.notify_whatsapp" class="rounded-full bg-white/60 p-2 shadow-inner dark:bg-neutral-800/80" title="WhatsApp">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="currentColor">
                       <path d="M12.031 6.172c-3.181 0-5.767 2.586-5.768 5.766-.001 1.298.38 2.27 1.019 3.287l-.582 2.128 2.182-.573c.978.58 1.911.928 3.145.929 3.178 0 5.767-2.587 5.768-5.766.001-3.187-2.575-5.77-5.764-5.771zm3.392 8.244c-.144.405-.837.774-1.17.824-.299.045-.677.063-1.092-.069-.252-.08-.575-.187-.988-.365-1.739-.751-2.874-2.502-2.961-2.617-.087-.116-.708-.94-.708-1.793s.448-1.273.607-1.446c.159-.173.346-.217.462-.217l.332.006c.106.005.249-.04.39.298.144.347.491 1.2.534 1.287.043.087.072.188.014.304-.058.116-.087.188-.173.289l-.26.304c-.087.086-.177.18-.076.354.101.174.449.741.964 1.201.662.591 1.221.774 1.394.86s.274.072.376-.043c.101-.116.433-.506.549-.68.116-.173.231-.145.39-.087s1.011.477 1.184.564c.173.087.289.13.332.202.043.72.043.433-.101.824z"/>
                       <path d="M12 0C5.373 0 0 5.373 0 12s5.373 12 12 12 12-5.373 12-12S18.627 0 12 0zm.029 18.88c-1.161 0-2.305-.292-3.318-.844l-3.677.964.984-3.595c-.607-1.052-.927-2.246-.926-3.468.001-3.825 3.113-6.937 6.937-6.937 1.856.001 3.598.723 4.907 2.034 1.31 1.311 2.031 3.054 2.03 4.908-.001 3.825-3.113 6.938-6.937 6.938z"/>
                     </svg>
                   </span>
                 </div>
               </td>
-              <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
-                <button @click="editAlert(alert)" class="text-secondary hover:text-secondary-dark mr-3">Modifier</button>
-                <button @click="confirmDeleteAlert(alert)" class="text-danger hover:text-danger-dark">Supprimer</button>
+              <td class="px-6 py-4 text-sm font-medium">
+                <button @click="editAlert(alert)" class="text-secondary hover:text-secondary-dark">Modifier</button>
+                <button @click="confirmDeleteAlert(alert)" class="ml-4 text-danger hover:text-danger-dark">Supprimer</button>
               </td>
             </tr>
           </tbody>
@@ -82,26 +89,50 @@
       </div>
     </div>
 
-    <!-- Message si aucune alerte -->
-    <div v-else class="text-center py-12">
-      <svg xmlns="http://www.w3.org/2000/svg" class="h-12 w-12 mx-auto text-neutral-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
-      </svg>
-      <h3 class="mt-2 text-sm font-medium text-neutral-900 dark:text-white">Aucune alerte</h3>
-      <p class="mt-1 text-sm text-neutral-500 dark:text-neutral-400">Commencez par créer une alerte pour être notifié des mouvements de prix.</p>
+    <div v-else class="section-card text-center">
+      <div class="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-primary/10 text-primary">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
+        </svg>
+      </div>
+      <h3 class="mt-4 text-lg font-semibold text-neutral-900 dark:text-white">Aucune alerte</h3>
+      <p class="mt-2 text-sm text-neutral-500 dark:text-neutral-400">
+        Créez une alerte pour recevoir vos notifications personnalisées.
+      </p>
+      <router-link
+        to="/alerts/create"
+        class="mt-4 inline-flex items-center gap-2 rounded-full bg-primary px-5 py-2 text-sm font-semibold text-white shadow hover:bg-primary-dark"
+      >
+        Commencer
+      </router-link>
     </div>
 
-    <!-- Paramètres de notification -->
-    <div class="mt-8">
-      <h2 class="text-lg font-semibold text-neutral-900 dark:text-white mb-4">Paramètres de notification</h2>
-      <div class="bg-neutral-50 dark:bg-neutral-700 p-6 rounded-lg">
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <div>
-            <h3 class="text-md font-medium text-neutral-900 dark:text-white mb-3">Canaux de notification</h3>
-            <div class="space-y-4">
+    <div class="section-card">
+      <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <p class="text-sm font-medium uppercase tracking-[0.3em] text-primary/70 dark:text-primary/60">Canaux</p>
+          <h2 class="text-xl font-semibold text-neutral-900 dark:text-white">Paramètres de notification</h2>
+          <p class="mt-2 text-sm text-neutral-500 dark:text-neutral-400">
+            Personnalisez vos canaux de diffusion et leurs identifiants pour être informé instantanément.
+          </p>
+        </div>
+        <button
+          @click="saveNotificationSettings"
+          class="inline-flex items-center gap-2 rounded-full bg-primary px-4 py-2 text-sm font-semibold text-white shadow hover:bg-primary-dark"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+          </svg>
+          Enregistrer
+        </button>
+      </div>
+      <div class="mt-8 grid grid-cols-1 gap-8 md:grid-cols-2">
+        <div>
+            <h3 class="text-md font-semibold text-neutral-900 dark:text-white">Canaux de notification</h3>
+            <div class="mt-5 space-y-4">
               <div class="flex items-center">
-                <input 
-                  id="notify-email" 
+                <input
+                  id="notify-email"
                   type="checkbox" 
                   v-model="notificationSettings.email_enabled"
                   class="h-4 w-4 text-primary focus:ring-primary border-neutral-300 dark:border-neutral-700 rounded dark:bg-neutral-800"
@@ -135,11 +166,11 @@
             </div>
           </div>
           <div>
-            <h3 class="text-md font-medium text-neutral-900 dark:text-white mb-3">Configuration</h3>
-            <div class="space-y-4">
+            <h3 class="text-md font-semibold text-neutral-900 dark:text-white">Configuration</h3>
+            <div class="mt-5 space-y-5">
               <div v-if="notificationSettings.telegram_enabled">
                 <label for="telegram-chat-id" class="block text-sm font-medium text-neutral-700 dark:text-neutral-300">ID de chat Telegram</label>
-                <input 
+                <input
                   type="text" 
                   id="telegram-chat-id" 
                   v-model="notificationSettings.telegram_chat_id" 
@@ -166,24 +197,15 @@
             </div>
           </div>
         </div>
-        <div class="mt-6">
-          <button 
-            @click="saveNotificationSettings"
-            class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-primary hover:bg-primary-dark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
-          >
-            Enregistrer les paramètres
-          </button>
-        </div>
       </div>
-    </div>
 
     <!-- Modal de confirmation de suppression -->
     <div v-if="showDeleteConfirmModal" class="fixed inset-0 z-10 overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true">
       <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
         <div class="fixed inset-0 bg-neutral-500 bg-opacity-75 transition-opacity" aria-hidden="true" @click="showDeleteConfirmModal = false"></div>
         <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
-        <div class="inline-block align-bottom bg-white dark:bg-neutral-800 rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
-          <div class="bg-white dark:bg-neutral-800 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+        <div class="modal-content glass-panel inline-block align-bottom text-left overflow-hidden transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
+          <div class="px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
             <div class="sm:flex sm:items-start">
               <div class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-danger-light sm:mx-0 sm:h-10 sm:w-10">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-danger" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -202,9 +224,9 @@
               </div>
             </div>
           </div>
-          <div class="bg-neutral-50 dark:bg-neutral-700 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
-            <button 
-              type="button" 
+          <div class="bg-white/60 px-4 py-3 backdrop-blur dark:bg-neutral-900/60 sm:flex sm:flex-row-reverse sm:px-6">
+            <button
+              type="button"
               @click="deleteAlert"
               class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-danger text-base font-medium text-white hover:bg-danger-dark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-danger sm:ml-3 sm:w-auto sm:text-sm"
             >
@@ -229,9 +251,13 @@ import { ref, onMounted } from 'vue'
 import { useStore } from 'vuex'
 import { useRouter } from 'vue-router'
 import { useToast } from 'vue-toastification'
+import PageHeader from '@/components/layout/PageHeader.vue'
 
 export default {
   name: 'Alerts',
+  components: {
+    PageHeader
+  },
   setup() {
     const store = useStore()
     const router = useRouter()

--- a/finance-app/frontend/src/views/Calendar.vue
+++ b/finance-app/frontend/src/views/Calendar.vue
@@ -1,172 +1,139 @@
 <template>
-  <div class="bg-white dark:bg-neutral-800 shadow rounded-lg p-6">
-    <div class="flex flex-col md:flex-row md:items-center md:justify-between mb-6">
-      <h1 class="text-2xl font-bold text-neutral-900 dark:text-white">Calendrier Financier</h1>
-      
-      <div class="mt-4 md:mt-0 flex space-x-2">
-        <button 
-          @click="prevMonth"
-          class="inline-flex items-center px-3 py-2 border border-neutral-300 dark:border-neutral-600 text-sm font-medium rounded-md text-neutral-700 dark:text-neutral-300 bg-white dark:bg-neutral-800 hover:bg-neutral-50 dark:hover:bg-neutral-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
-        >
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
-          </svg>
-        </button>
-        <span class="inline-flex items-center px-4 py-2 text-sm font-medium text-neutral-700 dark:text-neutral-300">
-          {{ formatMonth(currentMonth) }} {{ currentYear }}
-        </span>
-        <button 
-          @click="nextMonth"
-          class="inline-flex items-center px-3 py-2 border border-neutral-300 dark:border-neutral-600 text-sm font-medium rounded-md text-neutral-700 dark:text-neutral-300 bg-white dark:bg-neutral-800 hover:bg-neutral-50 dark:hover:bg-neutral-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
-        >
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-          </svg>
-        </button>
+  <div class="page-card space-y-10">
+    <page-header
+      eyebrow="Planification"
+      title="Calendrier financier"
+      description="Anticipez les publications économiques, résultats et annonces clés pour orchestrer vos décisions d'investissement."
+    />
+
+    <div class="section-card space-y-6">
+      <div class="flex flex-col items-start justify-between gap-6 md:flex-row md:items-center">
+        <div class="flex items-center gap-3 rounded-full bg-white/70 px-4 py-2 shadow-inner dark:bg-neutral-900/70">
+          <button
+            @click="prevMonth"
+            class="inline-flex h-9 w-9 items-center justify-center rounded-full text-neutral-600 transition hover:text-primary dark:text-neutral-300 dark:hover:text-primary"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+            </svg>
+          </button>
+          <span class="text-sm font-semibold tracking-wide text-neutral-700 dark:text-neutral-200">
+            {{ formatMonth(currentMonth) }} {{ currentYear }}
+          </span>
+          <button
+            @click="nextMonth"
+            class="inline-flex h-9 w-9 items-center justify-center rounded-full text-neutral-600 transition hover:text-primary dark:text-neutral-300 dark:hover:text-primary"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+            </svg>
+          </button>
+        </div>
+
+        <div class="flex flex-wrap gap-2">
+          <button
+            v-for="filter in filterOptions"
+            :key="filter.value"
+            @click="toggleFilter(filter.value)"
+            class="rounded-full px-4 py-2 text-xs font-medium uppercase tracking-wide transition"
+            :class="activeFilters.includes(filter.value)
+              ? 'bg-primary text-white shadow shadow-primary/30'
+              : 'bg-white/60 text-neutral-600 hover:bg-white dark:bg-neutral-800/70 dark:text-neutral-300 dark:hover:bg-neutral-800/90'"
+          >
+            {{ filter.label }}
+          </button>
+        </div>
       </div>
-    </div>
 
-    <!-- Filtres -->
-    <div class="mb-6">
-      <div class="flex flex-wrap gap-2">
-        <button 
-          @click="toggleFilter('all')"
-          class="px-3 py-1 text-sm rounded-md focus:outline-none"
-          :class="activeFilters.includes('all') ? 'bg-primary text-white' : 'bg-neutral-100 dark:bg-neutral-700 text-neutral-700 dark:text-neutral-300 hover:bg-neutral-200 dark:hover:bg-neutral-600'"
-        >
-          Tous
-        </button>
-        <button 
-          @click="toggleFilter('earnings')"
-          class="px-3 py-1 text-sm rounded-md focus:outline-none"
-          :class="activeFilters.includes('earnings') ? 'bg-primary text-white' : 'bg-neutral-100 dark:bg-neutral-700 text-neutral-700 dark:text-neutral-300 hover:bg-neutral-200 dark:hover:bg-neutral-600'"
-        >
-          Résultats
-        </button>
-        <button 
-          @click="toggleFilter('economic')"
-          class="px-3 py-1 text-sm rounded-md focus:outline-none"
-          :class="activeFilters.includes('economic') ? 'bg-primary text-white' : 'bg-neutral-100 dark:bg-neutral-700 text-neutral-700 dark:text-neutral-300 hover:bg-neutral-200 dark:hover:bg-neutral-600'"
-        >
-          Données économiques
-        </button>
-        <button 
-          @click="toggleFilter('central_bank')"
-          class="px-3 py-1 text-sm rounded-md focus:outline-none"
-          :class="activeFilters.includes('central_bank') ? 'bg-primary text-white' : 'bg-neutral-100 dark:bg-neutral-700 text-neutral-700 dark:text-neutral-300 hover:bg-neutral-200 dark:hover:bg-neutral-600'"
-        >
-          Banques centrales
-        </button>
-        <button 
-          @click="toggleFilter('ipo')"
-          class="px-3 py-1 text-sm rounded-md focus:outline-none"
-          :class="activeFilters.includes('ipo') ? 'bg-primary text-white' : 'bg-neutral-100 dark:bg-neutral-700 text-neutral-700 dark:text-neutral-300 hover:bg-neutral-200 dark:hover:bg-neutral-600'"
-        >
-          IPO
-        </button>
-        <button 
-          @click="toggleFilter('dividend')"
-          class="px-3 py-1 text-sm rounded-md focus:outline-none"
-          :class="activeFilters.includes('dividend') ? 'bg-primary text-white' : 'bg-neutral-100 dark:bg-neutral-700 text-neutral-700 dark:text-neutral-300 hover:bg-neutral-200 dark:hover:bg-neutral-600'"
-        >
-          Dividendes
-        </button>
-        <button 
-          @click="toggleFilter('split')"
-          class="px-3 py-1 text-sm rounded-md focus:outline-none"
-          :class="activeFilters.includes('split') ? 'bg-primary text-white' : 'bg-neutral-100 dark:bg-neutral-700 text-neutral-700 dark:text-neutral-300 hover:bg-neutral-200 dark:hover:bg-neutral-600'"
-        >
-          Splits
-        </button>
+      <div class="overflow-hidden rounded-2xl border border-white/40 dark:border-neutral-700/60">
+        <table class="min-w-full divide-y divide-white/40 dark:divide-neutral-800/60">
+          <thead class="bg-white/80 backdrop-blur dark:bg-neutral-900/70">
+            <tr>
+              <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider text-neutral-500 dark:text-neutral-400">Date</th>
+              <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider text-neutral-500 dark:text-neutral-400">Heure</th>
+              <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider text-neutral-500 dark:text-neutral-400">Événement</th>
+              <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider text-neutral-500 dark:text-neutral-400">Type</th>
+              <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider text-neutral-500 dark:text-neutral-400">Impact</th>
+              <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider text-neutral-500 dark:text-neutral-400">Actions</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-white/20 dark:divide-neutral-800/60">
+            <tr
+              v-for="event in filteredEvents"
+              :key="event.id"
+              class="bg-white/70 transition hover:bg-white/95 dark:bg-neutral-900/70 dark:hover:bg-neutral-900/85"
+            >
+              <td class="px-6 py-4 text-sm text-neutral-900 dark:text-white">{{ formatDate(event.date) }}</td>
+              <td class="px-6 py-4 text-sm text-neutral-600 dark:text-neutral-300">{{ formatTime(event.date) }}</td>
+              <td class="px-6 py-4">
+                <p class="text-sm font-semibold text-neutral-900 dark:text-white">{{ event.title }}</p>
+                <p class="mt-1 text-xs text-neutral-500 dark:text-neutral-400">{{ event.description }}</p>
+              </td>
+              <td class="px-6 py-4">
+                <span :class="eventTypeClass(event.type)">
+                  {{ formatEventType(event.type) }}
+                </span>
+              </td>
+              <td class="px-6 py-4">
+                <span :class="impactClass(event.impact)">
+                  {{ formatImpact(event.impact) }}
+                </span>
+              </td>
+              <td class="px-6 py-4 text-sm font-medium">
+                <div class="flex flex-wrap items-center gap-3">
+                  <button
+                    v-if="event.can_alert"
+                    @click="createAlert(event)"
+                    class="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold text-primary transition hover:bg-primary/20"
+                  >
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+                    </svg>
+                    Alerte
+                  </button>
+                  <button
+                    @click="addToCalendar(event)"
+                    class="inline-flex items-center gap-1 rounded-full bg-white/60 px-3 py-1 text-xs font-semibold text-secondary transition hover:bg-white dark:bg-neutral-800/70 dark:text-secondary-light dark:hover:bg-neutral-800"
+                  >
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                    </svg>
+                    Agenda
+                  </button>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
       </div>
-    </div>
 
-    <!-- Calendrier -->
-    <div class="overflow-x-auto">
-      <table class="min-w-full divide-y divide-neutral-200 dark:divide-neutral-600">
-        <thead>
-          <tr>
-            <th class="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">Date</th>
-            <th class="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">Heure</th>
-            <th class="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">Événement</th>
-            <th class="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">Type</th>
-            <th class="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">Impact</th>
-            <th class="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">Actions</th>
-          </tr>
-        </thead>
-        <tbody class="divide-y divide-neutral-200 dark:divide-neutral-600">
-          <tr v-for="event in filteredEvents" :key="event.id" class="hover:bg-neutral-50 dark:hover:bg-neutral-700">
-            <td class="px-6 py-4 whitespace-nowrap">
-              <div class="text-sm text-neutral-900 dark:text-white">{{ formatDate(event.date) }}</div>
-            </td>
-            <td class="px-6 py-4 whitespace-nowrap">
-              <div class="text-sm text-neutral-900 dark:text-white">{{ formatTime(event.date) }}</div>
-            </td>
-            <td class="px-6 py-4">
-              <div class="text-sm text-neutral-900 dark:text-white">{{ event.title }}</div>
-              <div class="text-xs text-neutral-500 dark:text-neutral-400">{{ event.description }}</div>
-            </td>
-            <td class="px-6 py-4 whitespace-nowrap">
-              <span :class="{
-                'px-2 py-1 text-xs font-medium rounded-full': true,
-                'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:bg-opacity-30 dark:text-blue-300': event.type === 'earnings',
-                'bg-green-100 text-green-800 dark:bg-green-900 dark:bg-opacity-30 dark:text-green-300': event.type === 'economic',
-                'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:bg-opacity-30 dark:text-purple-300': event.type === 'central_bank',
-                'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:bg-opacity-30 dark:text-yellow-300': event.type === 'ipo',
-                'bg-indigo-100 text-indigo-800 dark:bg-indigo-900 dark:bg-opacity-30 dark:text-indigo-300': event.type === 'dividend',
-                'bg-pink-100 text-pink-800 dark:bg-pink-900 dark:bg-opacity-30 dark:text-pink-300': event.type === 'split'
-              }">
-                {{ formatEventType(event.type) }}
-              </span>
-            </td>
-            <td class="px-6 py-4 whitespace-nowrap">
-              <span :class="{
-                'px-2 py-1 text-xs font-medium rounded-full': true,
-                'bg-danger-light text-danger': event.impact === 'high',
-                'bg-warning-light text-warning': event.impact === 'medium',
-                'bg-info-light text-info': event.impact === 'low'
-              }">
-                {{ formatImpact(event.impact) }}
-              </span>
-            </td>
-            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
-              <button 
-                @click="createAlert(event)"
-                class="text-primary hover:text-primary-dark"
-                v-if="event.can_alert"
-              >
-                Créer une alerte
-              </button>
-              <button 
-                @click="addToCalendar(event)"
-                class="text-secondary hover:text-secondary-dark ml-3"
-              >
-                Ajouter au calendrier
-              </button>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-
-    <!-- Message si aucun événement -->
-    <div v-if="filteredEvents.length === 0" class="text-center py-12">
-      <svg xmlns="http://www.w3.org/2000/svg" class="h-12 w-12 mx-auto text-neutral-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-      </svg>
-      <h3 class="mt-2 text-sm font-medium text-neutral-900 dark:text-white">Aucun événement</h3>
-      <p class="mt-1 text-sm text-neutral-500 dark:text-neutral-400">Aucun événement financier pour cette période avec les filtres sélectionnés.</p>
+      <div v-if="filteredEvents.length === 0" class="rounded-2xl border border-dashed border-neutral-200/70 py-12 text-center dark:border-neutral-700">
+        <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-primary/10 text-primary">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-7 w-7" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+          </svg>
+        </div>
+        <h3 class="mt-4 text-lg font-semibold text-neutral-900 dark:text-white">Aucun événement</h3>
+        <p class="mt-2 text-sm text-neutral-500 dark:text-neutral-400">
+          Ajustez vos filtres ou changez de période pour découvrir de nouvelles opportunités.
+        </p>
+      </div>
     </div>
   </div>
 </template>
+
 
 <script>
 import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useToast } from 'vue-toastification'
+import PageHeader from '@/components/layout/PageHeader.vue'
 
 export default {
   name: 'Calendar',
+  components: {
+    PageHeader
+  },
   setup() {
     const router = useRouter()
     const toast = useToast()
@@ -175,6 +142,16 @@ export default {
     const currentMonth = ref(new Date().getMonth())
     const currentYear = ref(new Date().getFullYear())
     const activeFilters = ref(['all'])
+
+    const filterOptions = [
+      { label: 'Tous', value: 'all' },
+      { label: 'Résultats', value: 'earnings' },
+      { label: 'Données économiques', value: 'economic' },
+      { label: 'Banques centrales', value: 'central_bank' },
+      { label: 'IPO', value: 'ipo' },
+      { label: 'Dividendes', value: 'dividend' },
+      { label: 'Splits', value: 'split' }
+    ]
 
     onMounted(() => {
       events.value = createSampleEvents(currentYear.value, currentMonth.value)
@@ -236,6 +213,27 @@ export default {
       } else {
         activeFilters.value.push(filter)
       }
+    }
+
+    const eventTypeClass = (type) => {
+      const mapping = {
+        earnings: 'badge bg-primary/15 text-primary',
+        economic: 'badge bg-success/15 text-success',
+        central_bank: 'badge bg-secondary/15 text-secondary',
+        ipo: 'badge bg-warning/15 text-warning',
+        dividend: 'badge bg-info/15 text-info',
+        split: 'badge bg-neutral-200 text-neutral-600 dark:bg-neutral-700 dark:text-neutral-300'
+      }
+      return mapping[type] || 'badge bg-neutral-200 text-neutral-600 dark:bg-neutral-700 dark:text-neutral-300'
+    }
+
+    const impactClass = (impact) => {
+      const mapping = {
+        high: 'badge bg-danger/15 text-danger',
+        medium: 'badge bg-warning/15 text-warning',
+        low: 'badge bg-info/15 text-info'
+      }
+      return mapping[impact] || 'badge bg-neutral-200 text-neutral-600 dark:bg-neutral-700 dark:text-neutral-300'
     }
 
     const createAlert = (event) => {
@@ -312,12 +310,15 @@ export default {
       currentMonth,
       currentYear,
       activeFilters,
+      filterOptions,
       filteredEvents,
       prevMonth,
       nextMonth,
       toggleFilter,
       createAlert,
       addToCalendar,
+      eventTypeClass,
+      impactClass,
       formatDate,
       formatTime,
       formatEventType,

--- a/finance-app/frontend/src/views/Dashboard.vue
+++ b/finance-app/frontend/src/views/Dashboard.vue
@@ -1,158 +1,193 @@
 <template>
-  <div class="bg-white dark:bg-neutral-800 shadow rounded-lg p-6">
-    <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
-      <!-- Widgets de suivi -->
+  <div class="page-card space-y-10">
+    <page-header
+      eyebrow="Vue d'ensemble"
+      title="Tableau de bord"
+      description="Visualisez en un clin d'œil la santé de vos marchés, portefeuilles et alertes actives."
+    />
+
+    <div class="grid grid-cols-1 gap-6 md:grid-cols-3">
       <div class="col-span-1">
-        <h2 class="text-lg font-semibold text-neutral-900 dark:text-white mb-4">Actifs favoris</h2>
-        <div v-if="favoriteAssets.length > 0" class="space-y-4">
-          <div v-for="asset in favoriteAssets" :key="asset.id" class="bg-neutral-50 dark:bg-neutral-700 p-4 rounded-lg">
-            <div class="flex justify-between items-center">
-              <div>
-                <h3 class="font-medium text-neutral-900 dark:text-white">{{ asset.symbol }}</h3>
-                <p class="text-sm text-neutral-500 dark:text-neutral-400">{{ asset.name }}</p>
-              </div>
-              <div class="text-right">
-                <p class="font-bold" :class="asset.priceChange >= 0 ? 'text-success' : 'text-danger'">
-                  {{ formatPrice(asset.last_price) }}
-                </p>
-                <p class="text-sm" :class="asset.priceChange >= 0 ? 'text-success' : 'text-danger'">
-                  {{ formatPercentage(asset.priceChange) }}
-                </p>
+        <div class="section-card h-full">
+          <div class="flex items-center justify-between">
+            <h2 class="text-lg font-semibold text-neutral-900 dark:text-white">Actifs favoris</h2>
+            <router-link
+              v-if="favoriteAssets.length === 0"
+              to="/analysis/technical"
+              class="inline-flex items-center gap-2 rounded-full bg-primary/10 px-3 py-1 text-xs font-medium text-primary transition hover:bg-primary/20"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+              </svg>
+              Ajouter
+            </router-link>
+          </div>
+          <div v-if="favoriteAssets.length > 0" class="mt-5 space-y-4">
+            <div v-for="asset in favoriteAssets" :key="asset.id" class="stat-card">
+              <div class="flex items-center justify-between">
+                <div>
+                  <h3 class="text-base font-semibold text-neutral-900 dark:text-white">{{ asset.symbol }}</h3>
+                  <p class="text-sm text-neutral-500 dark:text-neutral-400">{{ asset.name }}</p>
+                </div>
+                <div class="text-right">
+                  <p class="text-lg font-semibold" :class="asset.priceChange >= 0 ? 'text-success' : 'text-danger'">
+                    {{ formatPrice(asset.last_price) }}
+                  </p>
+                  <p class="text-sm font-medium" :class="asset.priceChange >= 0 ? 'text-success' : 'text-danger'">
+                    {{ formatPercentage(asset.priceChange) }}
+                  </p>
+                </div>
               </div>
             </div>
           </div>
-        </div>
-        <div v-else class="text-center py-4">
-          <p class="text-neutral-500 dark:text-neutral-400">Aucun actif favori</p>
-          <router-link to="/analysis/technical" class="mt-2 inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-primary hover:bg-primary-dark">
-            Ajouter des favoris
-          </router-link>
-        </div>
-      </div>
-
-      <!-- Widgets d'analyse -->
-      <div class="col-span-1">
-        <h2 class="text-lg font-semibold text-neutral-900 dark:text-white mb-4">Indices majeurs</h2>
-        <div class="space-y-4">
-          <div v-for="index in majorIndices" :key="index.symbol" class="bg-neutral-50 dark:bg-neutral-700 p-4 rounded-lg">
-            <div class="flex justify-between items-center">
-              <div>
-                <h3 class="font-medium text-neutral-900 dark:text-white">{{ index.symbol }}</h3>
-                <p class="text-sm text-neutral-500 dark:text-neutral-400">{{ index.name }}</p>
-              </div>
-              <div class="text-right">
-                <p class="font-bold" :class="index.change >= 0 ? 'text-success' : 'text-danger'">
-                  {{ formatPrice(index.price) }}
-                </p>
-                <p class="text-sm" :class="index.change >= 0 ? 'text-success' : 'text-danger'">
-                  {{ formatPercentage(index.change) }}
-                </p>
-              </div>
-            </div>
+          <div v-else class="mt-6 rounded-2xl border border-dashed border-neutral-200/70 py-6 text-center text-neutral-500 dark:border-neutral-700 dark:text-neutral-400">
+            <p>Ajoutez vos actifs préférés pour suivre leurs mouvements.</p>
           </div>
         </div>
       </div>
 
-      <!-- Widgets d'information -->
       <div class="col-span-1">
-        <h2 class="text-lg font-semibold text-neutral-900 dark:text-white mb-4">Alertes récentes</h2>
-        <div v-if="recentAlerts.length > 0" class="space-y-4">
-          <div v-for="alert in recentAlerts" :key="alert.id" class="bg-neutral-50 dark:bg-neutral-700 p-4 rounded-lg">
-            <div class="flex items-start">
-              <div class="flex-shrink-0">
-                <svg class="h-5 w-5 text-warning" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-                  <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
-                </svg>
-              </div>
-              <div class="ml-3">
-                <h3 class="text-sm font-medium text-neutral-900 dark:text-white">{{ alert.asset_symbol }}</h3>
-                <p class="text-xs text-neutral-500 dark:text-neutral-400">
-                  {{ alert.condition }} {{ formatPrice(alert.value) }}
-                </p>
-                <p class="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
-                  {{ formatDate(alert.triggered_at) }}
-                </p>
+        <div class="section-card h-full">
+          <h2 class="text-lg font-semibold text-neutral-900 dark:text-white">Indices majeurs</h2>
+          <div class="mt-5 space-y-4">
+            <div v-for="index in majorIndices" :key="index.symbol" class="stat-card">
+              <div class="flex items-center justify-between">
+                <div>
+                  <h3 class="text-base font-semibold text-neutral-900 dark:text-white">{{ index.symbol }}</h3>
+                  <p class="text-sm text-neutral-500 dark:text-neutral-400">{{ index.name }}</p>
+                </div>
+                <div class="text-right">
+                  <p class="text-lg font-semibold" :class="index.change >= 0 ? 'text-success' : 'text-danger'">
+                    {{ formatPrice(index.price) }}
+                  </p>
+                  <p class="text-sm font-medium" :class="index.change >= 0 ? 'text-success' : 'text-danger'">
+                    {{ formatPercentage(index.change) }}
+                  </p>
+                </div>
               </div>
             </div>
           </div>
         </div>
-        <div v-else class="text-center py-4">
-          <p class="text-neutral-500 dark:text-neutral-400">Aucune alerte récente</p>
-          <router-link to="/alerts/create" class="mt-2 inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-primary hover:bg-primary-dark">
-            Créer une alerte
-          </router-link>
+      </div>
+
+      <div class="col-span-1">
+        <div class="section-card h-full">
+          <h2 class="text-lg font-semibold text-neutral-900 dark:text-white">Alertes récentes</h2>
+          <div v-if="recentAlerts.length > 0" class="mt-5 space-y-4">
+            <div v-for="alert in recentAlerts" :key="alert.id" class="stat-card">
+              <div class="flex items-start gap-3">
+                <div class="flex h-10 w-10 items-center justify-center rounded-2xl bg-warning/10 text-warning">
+                  <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+                    <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
+                  </svg>
+                </div>
+                <div>
+                  <h3 class="text-sm font-semibold text-neutral-900 dark:text-white">{{ alert.asset_symbol }}</h3>
+                  <p class="text-xs text-neutral-500 dark:text-neutral-400">
+                    {{ alert.condition }} {{ formatPrice(alert.value) }}
+                  </p>
+                  <p class="mt-1 text-xs text-neutral-400 dark:text-neutral-500">
+                    {{ formatDate(alert.triggered_at) }}
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div v-else class="mt-6 rounded-2xl border border-dashed border-neutral-200/70 py-6 text-center text-neutral-500 dark:border-neutral-700 dark:text-neutral-400">
+            <p>Aucune alerte déclenchée récemment.</p>
+            <router-link
+              to="/alerts/create"
+              class="mt-3 inline-flex items-center gap-2 rounded-full bg-primary px-4 py-2 text-sm font-medium text-white shadow hover:bg-primary-dark"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+              </svg>
+              Créer une alerte
+            </router-link>
+          </div>
         </div>
       </div>
     </div>
 
-    <!-- Performances du portefeuille -->
-    <div class="mt-8">
-      <h2 class="text-lg font-semibold text-neutral-900 dark:text-white mb-4">Performance du portefeuille</h2>
-      <div v-if="portfolioPerformance" class="bg-neutral-50 dark:bg-neutral-700 p-6 rounded-lg">
-        <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
-          <div class="text-center">
-            <p class="text-sm text-neutral-500 dark:text-neutral-400">Valeur totale</p>
-            <p class="text-2xl font-bold text-neutral-900 dark:text-white">{{ formatPrice(portfolioPerformance.current_value) }}</p>
+    <div class="space-y-6">
+      <div>
+        <div class="section-card">
+          <div class="flex items-center justify-between">
+            <h2 class="text-lg font-semibold text-neutral-900 dark:text-white">Performance du portefeuille</h2>
+            <router-link
+              v-if="!portfolioPerformance"
+              to="/portfolio"
+              class="inline-flex items-center gap-2 rounded-full bg-primary/10 px-3 py-1 text-xs font-medium text-primary transition hover:bg-primary/20"
+            >
+              Configurer
+            </router-link>
           </div>
-          <div class="text-center">
-            <p class="text-sm text-neutral-500 dark:text-neutral-400">Investissement</p>
-            <p class="text-2xl font-bold text-neutral-900 dark:text-white">{{ formatPrice(portfolioPerformance.total_invested) }}</p>
+          <div v-if="portfolioPerformance" class="mt-6 grid grid-cols-1 gap-4 md:grid-cols-4">
+            <div class="stat-card text-center">
+              <p class="text-sm text-neutral-500 dark:text-neutral-400">Valeur totale</p>
+              <p class="mt-2 text-2xl font-semibold text-neutral-900 dark:text-white">{{ formatPrice(portfolioPerformance.current_value) }}</p>
+            </div>
+            <div class="stat-card text-center">
+              <p class="text-sm text-neutral-500 dark:text-neutral-400">Investissement</p>
+              <p class="mt-2 text-2xl font-semibold text-neutral-900 dark:text-white">{{ formatPrice(portfolioPerformance.total_invested) }}</p>
+            </div>
+            <div class="stat-card text-center">
+              <p class="text-sm text-neutral-500 dark:text-neutral-400">Profit/Perte</p>
+              <p class="mt-2 text-2xl font-semibold" :class="portfolioPerformance.profit_loss >= 0 ? 'text-success' : 'text-danger'">
+                {{ formatPrice(portfolioPerformance.profit_loss) }}
+              </p>
+            </div>
+            <div class="stat-card text-center">
+              <p class="text-sm text-neutral-500 dark:text-neutral-400">Rendement</p>
+              <p class="mt-2 text-2xl font-semibold" :class="portfolioPerformance.profit_loss_percentage >= 0 ? 'text-success' : 'text-danger'">
+                {{ formatPercentage(portfolioPerformance.profit_loss_percentage) }}
+              </p>
+            </div>
           </div>
-          <div class="text-center">
-            <p class="text-sm text-neutral-500 dark:text-neutral-400">Profit/Perte</p>
-            <p class="text-2xl font-bold" :class="portfolioPerformance.profit_loss >= 0 ? 'text-success' : 'text-danger'">
-              {{ formatPrice(portfolioPerformance.profit_loss) }}
-            </p>
-          </div>
-          <div class="text-center">
-            <p class="text-sm text-neutral-500 dark:text-neutral-400">Rendement</p>
-            <p class="text-2xl font-bold" :class="portfolioPerformance.profit_loss_percentage >= 0 ? 'text-success' : 'text-danger'">
-              {{ formatPercentage(portfolioPerformance.profit_loss_percentage) }}
-            </p>
+          <div v-else class="mt-6 rounded-2xl border border-dashed border-neutral-200/70 px-6 py-8 text-center text-neutral-500 dark:border-neutral-700 dark:text-neutral-400">
+            <p>Créez un portefeuille pour suivre votre performance globale.</p>
+            <router-link
+              to="/portfolio"
+              class="mt-4 inline-flex items-center gap-2 rounded-full bg-primary px-4 py-2 text-sm font-medium text-white shadow hover:bg-primary-dark"
+            >
+              Créer un portefeuille
+            </router-link>
           </div>
         </div>
       </div>
-      <div v-else class="text-center py-8 bg-neutral-50 dark:bg-neutral-700 rounded-lg">
-        <p class="text-neutral-500 dark:text-neutral-400">Aucun portefeuille actif</p>
-        <router-link to="/portfolio" class="mt-2 inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-primary hover:bg-primary-dark">
-          Créer un portefeuille
-        </router-link>
-      </div>
-    </div>
 
-    <!-- Calendrier financier -->
-    <div class="mt-8">
-      <h2 class="text-lg font-semibold text-neutral-900 dark:text-white mb-4">Événements financiers à venir</h2>
-      <div class="bg-neutral-50 dark:bg-neutral-700 p-6 rounded-lg">
-        <div v-if="upcomingEvents.length > 0" class="overflow-x-auto">
-          <table class="min-w-full divide-y divide-neutral-200 dark:divide-neutral-600">
-            <thead>
-              <tr>
-                <th class="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">Date</th>
-                <th class="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">Événement</th>
-                <th class="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">Impact</th>
-              </tr>
-            </thead>
-            <tbody class="divide-y divide-neutral-200 dark:divide-neutral-600">
-              <tr v-for="event in upcomingEvents" :key="event.id">
-                <td class="px-6 py-4 whitespace-nowrap text-sm text-neutral-900 dark:text-white">{{ formatDate(event.date) }}</td>
-                <td class="px-6 py-4 whitespace-nowrap text-sm text-neutral-900 dark:text-white">{{ event.title }}</td>
-                <td class="px-6 py-4 whitespace-nowrap">
-                  <span :class="{
-                    'px-2 py-1 text-xs font-medium rounded-full': true,
-                    'bg-danger-light text-danger': event.impact === 'high',
-                    'bg-warning-light text-warning': event.impact === 'medium',
-                    'bg-info-light text-info': event.impact === 'low'
-                  }">
-                    {{ event.impact }}
-                  </span>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-        <div v-else class="text-center py-4">
-          <p class="text-neutral-500 dark:text-neutral-400">Aucun événement à venir</p>
+      <div>
+        <div class="section-card">
+          <h2 class="text-lg font-semibold text-neutral-900 dark:text-white">Événements financiers à venir</h2>
+          <div v-if="upcomingEvents.length > 0" class="mt-6 overflow-hidden rounded-2xl border border-white/40 dark:border-neutral-700/60">
+            <table class="min-w-full divide-y divide-white/40 dark:divide-neutral-700/60">
+              <thead class="bg-white/70 backdrop-blur dark:bg-neutral-900/70">
+                <tr>
+                  <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-neutral-500 dark:text-neutral-400">Date</th>
+                  <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-neutral-500 dark:text-neutral-400">Événement</th>
+                  <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-neutral-500 dark:text-neutral-400">Impact</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-white/30 dark:divide-neutral-800/60">
+                <tr v-for="event in upcomingEvents" :key="event.id" class="bg-white/60 transition hover:bg-white/90 dark:bg-neutral-900/60 dark:hover:bg-neutral-900/80">
+                  <td class="px-6 py-4 text-sm text-neutral-900 dark:text-white">{{ formatDate(event.date) }}</td>
+                  <td class="px-6 py-4 text-sm text-neutral-900 dark:text-white">{{ event.title }}</td>
+                  <td class="px-6 py-4 text-sm">
+                    <span :class="{
+                      'badge bg-danger/15 text-danger': event.impact === 'high',
+                      'badge bg-warning/15 text-warning': event.impact === 'medium',
+                      'badge bg-info/15 text-info': event.impact === 'low'
+                    }">
+                      {{ event.impact }}
+                    </span>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div v-else class="mt-6 rounded-2xl border border-dashed border-neutral-200/70 py-6 text-center text-neutral-500 dark:border-neutral-700 dark:text-neutral-400">
+            <p>Aucun événement à venir pour le moment.</p>
+          </div>
         </div>
       </div>
     </div>
@@ -163,9 +198,13 @@
 import { ref, onMounted, computed } from 'vue'
 import { useStore } from 'vuex'
 import { useRouter } from 'vue-router'
+import PageHeader from '@/components/layout/PageHeader.vue'
 
 export default {
   name: 'Dashboard',
+  components: {
+    PageHeader
+  },
   setup() {
     const store = useStore()
     const router = useRouter()

--- a/finance-app/frontend/src/views/Login.vue
+++ b/finance-app/frontend/src/views/Login.vue
@@ -1,18 +1,23 @@
 <template>
-  <div class="min-h-screen flex items-center justify-center bg-neutral-100 dark:bg-neutral-900 py-12 px-4 sm:px-6 lg:px-8">
-    <div class="max-w-md w-full space-y-8">
-      <div>
-        <h2 class="mt-6 text-center text-3xl font-extrabold text-neutral-900 dark:text-white">
+  <div class="auth-shell">
+    <div class="auth-card space-y-8">
+      <div class="text-center space-y-3">
+        <div class="mx-auto inline-flex h-14 w-14 items-center justify-center rounded-2xl bg-primary/15 text-primary">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-7 w-7" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z" />
+          </svg>
+        </div>
+        <h2 class="text-3xl font-semibold tracking-tight text-neutral-900 dark:text-white">
           Connexion à votre compte
         </h2>
-        <p class="mt-2 text-center text-sm text-neutral-600 dark:text-neutral-400">
+        <p class="text-sm text-neutral-500 dark:text-neutral-400">
           Ou
-          <router-link to="/register" class="font-medium text-primary hover:text-primary-dark">
+          <router-link to="/register" class="font-semibold text-primary hover:text-primary-light">
             créez un nouveau compte
           </router-link>
         </p>
       </div>
-      <form class="mt-8 space-y-6" @submit.prevent="login">
+      <form class="space-y-6" @submit.prevent="login">
         <div class="rounded-md shadow-sm -space-y-px">
           <div>
             <label for="email-address" class="sr-only">Adresse email</label>
@@ -67,12 +72,12 @@
           <button
             type="submit"
             :disabled="loading"
-            class="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-primary hover:bg-primary-dark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
+            class="group relative w-full flex justify-center overflow-hidden rounded-full bg-primary px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-primary/30 transition hover:bg-primary-dark focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
           >
             <span class="absolute left-0 inset-y-0 flex items-center pl-3">
               <svg
                 v-if="!loading"
-                class="h-5 w-5 text-primary-dark group-hover:text-primary-light"
+                class="h-5 w-5 text-primary-light group-hover:text-white"
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 20 20"
                 fill="currentColor"

--- a/finance-app/frontend/src/views/Portfolio.vue
+++ b/finance-app/frontend/src/views/Portfolio.vue
@@ -1,55 +1,65 @@
 <template>
-  <div class="bg-white dark:bg-neutral-800 shadow rounded-lg p-6">
-    <div class="flex flex-col md:flex-row md:items-center md:justify-between mb-6">
-      <h1 class="text-2xl font-bold text-neutral-900 dark:text-white">Gestion de Portefeuille</h1>
+  <div class="page-card space-y-10">
+    <page-header
+      eyebrow="Gestion"
+      title="Portefeuilles intelligents"
+      description="Structurez vos investissements, suivez vos performances et adaptez vos stratégies en toute clarté."
+    >
+      <template #actions>
+        <button
+          @click="showCreatePortfolioModal = true"
+          class="inline-flex items-center gap-2 rounded-full bg-primary px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-primary/30 transition hover:bg-primary-dark"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+          </svg>
+          Nouveau portefeuille
+        </button>
+      </template>
+    </page-header>
 
-      <button
-        @click="showCreatePortfolioModal = true"
-        class="mt-4 md:mt-0 inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-primary hover:bg-primary-dark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
-      >
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
-        </svg>
-        Créer un portefeuille
-      </button>
-    </div>
-
-    <div v-if="portfolios.length > 0" class="mb-8">
+    <div v-if="portfolios.length > 0" class="section-card overflow-hidden">
       <div class="overflow-x-auto">
-        <table class="min-w-full divide-y divide-neutral-200 dark:divide-neutral-600">
+        <table class="min-w-full divide-y divide-white/40 dark:divide-neutral-800/60">
           <thead>
             <tr>
-              <th class="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">Nom</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">Valeur</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">Profit/Perte</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">Rendement</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">Actions</th>
+              <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider text-neutral-500 dark:text-neutral-400">Nom</th>
+              <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider text-neutral-500 dark:text-neutral-400">Valeur</th>
+              <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider text-neutral-500 dark:text-neutral-400">Profit/Perte</th>
+              <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider text-neutral-500 dark:text-neutral-400">Rendement</th>
+              <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider text-neutral-500 dark:text-neutral-400">Actions</th>
             </tr>
           </thead>
-          <tbody class="divide-y divide-neutral-200 dark:divide-neutral-600">
-            <tr v-for="portfolio in portfolios" :key="portfolio.id" class="hover:bg-neutral-50 dark:hover:bg-neutral-700">
+          <tbody class="divide-y divide-white/30 dark:divide-neutral-800/60">
+            <tr v-for="portfolio in portfolios" :key="portfolio.id" class="bg-white/70 transition hover:bg-white/95 dark:bg-neutral-900/70 dark:hover:bg-neutral-900/85">
               <td class="px-6 py-4 whitespace-nowrap">
                 <div class="flex items-center">
-                  <div class="text-sm font-medium text-neutral-900 dark:text-white">{{ portfolio.name }}</div>
+                  <div class="mr-3 inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-primary/10 text-primary font-semibold">
+                    {{ portfolio.name.substring(0, 2).toUpperCase() }}
+                  </div>
+                  <div>
+                    <div class="text-sm font-semibold text-neutral-900 dark:text-white">{{ portfolio.name }}</div>
+                    <p class="text-xs text-neutral-500 dark:text-neutral-400" v-if="portfolio.description">{{ portfolio.description }}</p>
+                  </div>
                 </div>
               </td>
               <td class="px-6 py-4 whitespace-nowrap">
-                <div class="text-sm text-neutral-900 dark:text-white">{{ formatPrice(portfolio.current_value) }}</div>
+                <div class="text-sm font-semibold text-neutral-900 dark:text-white">{{ formatPrice(portfolio.current_value) }}</div>
               </td>
               <td class="px-6 py-4 whitespace-nowrap">
-                <div class="text-sm" :class="portfolio.profit_loss >= 0 ? 'text-success' : 'text-danger'">
+                <div class="text-sm font-semibold" :class="portfolio.profit_loss >= 0 ? 'text-success' : 'text-danger'">
                   {{ formatPrice(portfolio.profit_loss) }}
                 </div>
               </td>
               <td class="px-6 py-4 whitespace-nowrap">
-                <div class="text-sm" :class="portfolio.profit_loss_percentage >= 0 ? 'text-success' : 'text-danger'">
+                <div class="text-sm font-semibold" :class="portfolio.profit_loss_percentage >= 0 ? 'text-success' : 'text-danger'">
                   {{ formatPercentage(portfolio.profit_loss_percentage) }}
                 </div>
               </td>
               <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
-                <router-link :to="`/portfolio/${portfolio.id}`" class="text-primary hover:text-primary-dark mr-3">Détails</router-link>
-                <button @click="editPortfolio(portfolio)" class="text-secondary hover:text-secondary-dark mr-3">Modifier</button>
-                <button @click="confirmDeletePortfolio(portfolio)" class="text-danger hover:text-danger-dark">Supprimer</button>
+                <router-link :to="`/portfolio/${portfolio.id}`" class="rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold text-primary transition hover:bg-primary/20">Détails</router-link>
+                <button @click="editPortfolio(portfolio)" class="ml-2 rounded-full bg-secondary/10 px-3 py-1 text-xs font-semibold text-secondary transition hover:bg-secondary/20">Modifier</button>
+                <button @click="confirmDeletePortfolio(portfolio)" class="ml-2 rounded-full bg-danger/10 px-3 py-1 text-xs font-semibold text-danger transition hover:bg-danger/20">Supprimer</button>
               </td>
             </tr>
           </tbody>
@@ -57,20 +67,28 @@
       </div>
     </div>
 
-    <div v-else class="text-center py-12">
-      <svg xmlns="http://www.w3.org/2000/svg" class="h-12 w-12 mx-auto text-neutral-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z" />
-      </svg>
-      <h3 class="mt-2 text-sm font-medium text-neutral-900 dark:text-white">Aucun portefeuille</h3>
-      <p class="mt-1 text-sm text-neutral-500 dark:text-neutral-400">Commencez par créer un portefeuille pour suivre vos investissements.</p>
+    <div v-else class="section-card text-center">
+      <div class="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-primary/10 text-primary">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z" />
+        </svg>
+      </div>
+      <h3 class="mt-4 text-lg font-semibold text-neutral-900 dark:text-white">Aucun portefeuille</h3>
+      <p class="mt-2 text-sm text-neutral-500 dark:text-neutral-400">Créez votre premier portefeuille pour suivre vos investissements en temps réel.</p>
+      <button
+        @click="showCreatePortfolioModal = true"
+        class="mt-4 inline-flex items-center gap-2 rounded-full bg-primary px-5 py-2 text-sm font-semibold text-white shadow hover:bg-primary-dark"
+      >
+        Créer un portefeuille
+      </button>
     </div>
 
     <div v-if="showCreatePortfolioModal" class="fixed inset-0 z-10 overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true">
       <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
         <div class="fixed inset-0 bg-neutral-500 bg-opacity-75 transition-opacity" aria-hidden="true" @click="showCreatePortfolioModal = false"></div>
         <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
-        <div class="inline-block align-bottom bg-white dark:bg-neutral-800 rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
-          <div class="bg-white dark:bg-neutral-800 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+        <div class="modal-content glass-panel inline-block align-bottom text-left overflow-hidden transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
+          <div class="px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
             <div class="sm:flex sm:items-start">
               <div class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-primary-light sm:mx-0 sm:h-10 sm:w-10">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -122,7 +140,7 @@
               </div>
             </div>
           </div>
-          <div class="bg-neutral-50 dark:bg-neutral-700 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
+          <div class="bg-white/60 px-4 py-3 backdrop-blur dark:bg-neutral-900/60 sm:flex sm:flex-row-reverse sm:px-6">
             <button
               type="button"
               @click="savePortfolio"
@@ -146,8 +164,8 @@
       <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
         <div class="fixed inset-0 bg-neutral-500 bg-opacity-75 transition-opacity" aria-hidden="true" @click="showDeleteConfirmModal = false"></div>
         <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
-        <div class="inline-block align-bottom bg-white dark:bg-neutral-800 rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
-          <div class="bg-white dark:bg-neutral-800 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+        <div class="modal-content glass-panel inline-block align-bottom text-left overflow-hidden transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
+          <div class="px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
             <div class="sm:flex sm:items-start">
               <div class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-danger-light sm:mx-0 sm:h-10 sm:w-10">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-danger" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -166,7 +184,7 @@
               </div>
             </div>
           </div>
-          <div class="bg-neutral-50 dark:bg-neutral-700 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
+          <div class="bg-white/60 px-4 py-3 backdrop-blur dark:bg-neutral-900/60 sm:flex sm:flex-row-reverse sm:px-6">
             <button
               type="button"
               @click="deletePortfolio"
@@ -193,9 +211,13 @@ import { ref, onMounted } from 'vue'
 import { useStore } from 'vuex'
 import { useRouter, useRoute } from 'vue-router'
 import { useToast } from 'vue-toastification'
+import PageHeader from '@/components/layout/PageHeader.vue'
 
 export default {
   name: 'Portfolio',
+  components: {
+    PageHeader
+  },
   setup() {
     const store = useStore()
     const router = useRouter()

--- a/finance-app/frontend/src/views/Register.vue
+++ b/finance-app/frontend/src/views/Register.vue
@@ -1,18 +1,23 @@
 <template>
-  <div class="min-h-screen flex items-center justify-center bg-neutral-100 dark:bg-neutral-900 py-12 px-4 sm:px-6 lg:px-8">
-    <div class="max-w-md w-full space-y-8">
-      <div>
-        <h2 class="mt-6 text-center text-3xl font-extrabold text-neutral-900 dark:text-white">
+  <div class="auth-shell">
+    <div class="auth-card space-y-8">
+      <div class="text-center space-y-3">
+        <div class="mx-auto inline-flex h-14 w-14 items-center justify-center rounded-2xl bg-primary/15 text-primary">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-7 w-7" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+          </svg>
+        </div>
+        <h2 class="text-3xl font-semibold tracking-tight text-neutral-900 dark:text-white">
           Créer un compte
         </h2>
-        <p class="mt-2 text-center text-sm text-neutral-600 dark:text-neutral-400">
+        <p class="text-sm text-neutral-500 dark:text-neutral-400">
           Ou
-          <router-link to="/login" class="font-medium text-primary hover:text-primary-dark">
+          <router-link to="/login" class="font-semibold text-primary hover:text-primary-light">
             connectez-vous à votre compte existant
           </router-link>
         </p>
       </div>
-      <form class="mt-8 space-y-6" @submit.prevent="register">
+      <form class="space-y-6" @submit.prevent="register">
         <div class="rounded-md shadow-sm -space-y-px">
           <div>
             <label for="full-name" class="sr-only">Nom complet</label>
@@ -71,12 +76,12 @@
           <button
             type="submit"
             :disabled="loading || !isFormValid"
-            class="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-primary hover:bg-primary-dark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary disabled:opacity-50"
+            class="group relative w-full flex justify-center overflow-hidden rounded-full bg-primary px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-primary/30 transition hover:bg-primary-dark focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:opacity-50"
           >
             <span class="absolute left-0 inset-y-0 flex items-center pl-3">
               <svg
                 v-if="!loading"
-                class="h-5 w-5 text-primary-dark group-hover:text-primary-light"
+                class="h-5 w-5 text-primary-light group-hover:text-white"
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 20 20"
                 fill="currentColor"

--- a/finance-app/frontend/src/views/Settings.vue
+++ b/finance-app/frontend/src/views/Settings.vue
@@ -1,12 +1,14 @@
 <template>
-  <div class="bg-white dark:bg-neutral-800 shadow rounded-lg p-6">
-    <div class="flex flex-col md:flex-row md:items-center md:justify-between mb-6">
-      <h1 class="text-2xl font-bold text-neutral-900 dark:text-white">Paramètres</h1>
-    </div>
+  <div class="page-card space-y-10">
+    <page-header
+      eyebrow="Personnalisation"
+      title="Paramètres avancés"
+      description="Ajustez votre profil, sécurisez l'accès et adaptez la plateforme à vos préférences."
+    />
 
-    <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+    <div class="grid grid-cols-1 gap-6 md:grid-cols-3">
       <div class="col-span-1">
-        <div class="bg-neutral-50 dark:bg-neutral-700 p-6 rounded-lg">
+        <div class="section-card h-full">
           <h2 class="text-lg font-semibold text-neutral-900 dark:text-white mb-4">Profil utilisateur</h2>
 
           <div class="flex items-center mb-6">
@@ -51,7 +53,7 @@
       </div>
 
       <div class="col-span-1">
-        <div class="bg-neutral-50 dark:bg-neutral-700 p-6 rounded-lg">
+        <div class="section-card h-full">
           <h2 class="text-lg font-semibold text-neutral-900 dark:text-white mb-4">Sécurité</h2>
 
           <form @submit.prevent="updatePassword">
@@ -97,7 +99,7 @@
       </div>
 
       <div class="col-span-1">
-        <div class="bg-neutral-50 dark:bg-neutral-700 p-6 rounded-lg">
+        <div class="section-card h-full">
           <h2 class="text-lg font-semibold text-neutral-900 dark:text-white mb-4">Préférences</h2>
 
           <div class="mb-6">
@@ -156,8 +158,7 @@
       </div>
     </div>
 
-    <div class="mt-6">
-      <div class="bg-neutral-50 dark:bg-neutral-700 p-6 rounded-lg">
+    <div class="section-card">
         <h2 class="text-lg font-semibold text-neutral-900 dark:text-white mb-4">Paramètres de notification</h2>
 
         <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
@@ -232,20 +233,22 @@
           </div>
         </div>
 
-        <div class="mt-6">
+        <div class="mt-6 flex justify-end">
           <button
             @click="saveNotificationSettings"
-            class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-primary hover:bg-primary-dark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
+            class="inline-flex items-center gap-2 rounded-full bg-primary px-5 py-2 text-sm font-semibold text-white shadow hover:bg-primary-dark"
           >
-            Enregistrer les paramètres de notification
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+            </svg>
+            Enregistrer les notifications
           </button>
         </div>
       </div>
     </div>
 
-    <div class="mt-6">
-      <div class="bg-neutral-50 dark:bg-neutral-700 p-6 rounded-lg">
-        <h2 class="text-lg font-semibold text-neutral-900 dark:text-white mb-4">Exportation de données</h2>
+    <div class="section-card space-y-6">
+      <h2 class="text-lg font-semibold text-neutral-900 dark:text-white">Exportation de données</h2>
 
         <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
           <div>
@@ -253,10 +256,10 @@
             <p class="text-sm text-neutral-500 dark:text-neutral-400 mb-4">
               Exportez vos données pour les sauvegarder ou les utiliser dans d'autres applications.
             </p>
-            <div class="space-y-4">
+            <div class="space-y-3">
               <button
                 @click="exportPortfolios"
-                class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-primary hover:bg-primary-dark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
+                class="inline-flex w-full items-center justify-center gap-2 rounded-full bg-primary px-5 py-2 text-sm font-semibold text-white shadow hover:bg-primary-dark"
               >
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
@@ -265,7 +268,7 @@
               </button>
               <button
                 @click="exportAlerts"
-                class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-primary hover:bg-primary-dark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
+                class="inline-flex w-full items-center justify-center gap-2 rounded-full bg-primary px-5 py-2 text-sm font-semibold text-white shadow hover:bg-primary-dark"
               >
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
@@ -281,7 +284,7 @@
             </p>
             <button
               @click="showDeleteAccountModal = true"
-              class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-danger hover:bg-danger-dark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-danger"
+              class="inline-flex items-center gap-2 rounded-full bg-danger px-5 py-2 text-sm font-semibold text-white shadow hover:bg-danger-dark"
             >
               <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.14 21H7.86a2 2 0 01-1.993-1.858L5 7m5 4v6m4-6v6M9 7h6m-7 0h8l1-2.5A2 2 0 0015.13 3H8.87a2 2 0 00-1.87 1.5L6 7z" />
@@ -291,14 +294,13 @@
           </div>
         </div>
       </div>
-    </div>
 
     <div v-if="showDeleteAccountModal" class="fixed inset-0 z-10 overflow-y-auto" role="dialog" aria-modal="true">
       <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
         <div class="fixed inset-0 bg-neutral-500 bg-opacity-75 transition-opacity" aria-hidden="true" @click="showDeleteAccountModal = false"></div>
         <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
-        <div class="inline-block align-bottom bg-white dark:bg-neutral-800 rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
-          <div class="bg-white dark:bg-neutral-800 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+        <div class="modal-content glass-panel inline-block align-bottom text-left overflow-hidden transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
+          <div class="px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
             <div class="sm:flex sm:items-start">
               <div class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-danger-light sm:mx-0 sm:h-10 sm:w-10">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-danger" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -315,7 +317,7 @@
               </div>
             </div>
           </div>
-          <div class="bg-neutral-50 dark:bg-neutral-700 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
+          <div class="bg-white/60 px-4 py-3 backdrop-blur dark:bg-neutral-900/60 sm:flex sm:flex-row-reverse sm:px-6">
             <button
               type="button"
               @click="deleteAccount"
@@ -334,18 +336,22 @@
         </div>
       </div>
     </div>
-  </div>
+  
 </template>
 
 <script>
 import { ref, computed, onMounted } from 'vue'
 import { useStore } from 'vuex'
 import { useToast } from 'vue-toastification'
+import PageHeader from '@/components/layout/PageHeader.vue'
 
 const PREFERENCES_KEY = 'finance-app-preferences'
 
 export default {
   name: 'Settings',
+  components: {
+    PageHeader
+  },
   setup() {
     const store = useStore()
     const toast = useToast()

--- a/finance-app/frontend/src/views/analysis/TechnicalAnalysis.vue
+++ b/finance-app/frontend/src/views/analysis/TechnicalAnalysis.vue
@@ -1,41 +1,46 @@
 <template>
-  <div class="bg-white dark:bg-neutral-800 shadow rounded-lg p-6">
-    <div class="flex flex-col md:flex-row md:items-center md:justify-between mb-6">
-      <h1 class="text-2xl font-bold text-neutral-900 dark:text-white">Analyse Technique</h1>
+  <div class="page-card space-y-8">
+    <page-header
+      eyebrow="Analyse"
+      title="Analyse technique avancée"
+      description="Explorez vos actifs favoris, activez des indicateurs dynamiques et identifiez les signaux clés du marché."
+    />
 
-      <div class="mt-4 md:mt-0 relative w-full md:w-auto">
-        <div class="flex">
-          <input
-            type="text"
-            v-model="searchQuery"
-            @input="searchAssets"
-            placeholder="Rechercher un actif..."
-            class="w-full md:w-64 px-4 py-2 border border-neutral-300 dark:border-neutral-600 rounded-l-md focus:outline-none focus:ring-primary focus:border-primary dark:bg-neutral-700 dark:text-white"
-          />
-          <button
-            class="bg-primary text-white px-4 py-2 rounded-r-md hover:bg-primary-dark focus:outline-none"
-            @click="searchAssets"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-            </svg>
-          </button>
-        </div>
-
-        <div
-          v-if="searchResults.length > 0"
-          class="absolute z-10 mt-1 w-full bg-white dark:bg-neutral-800 shadow-lg rounded-md max-h-60 overflow-y-auto"
-        >
-          <ul class="py-1">
-            <li
-              v-for="result in searchResults"
-              :key="result.symbol"
-              class="px-4 py-2 hover:bg-neutral-100 dark:hover:bg-neutral-700 cursor-pointer"
-              @click="selectAsset(result)"
+    <div class="section-card space-y-6">
+      <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div class="relative w-full md:w-auto">
+          <div class="flex">
+            <input
+              type="text"
+              v-model="searchQuery"
+              @input="searchAssets"
+              placeholder="Rechercher un actif..."
+              class="w-full md:w-64 rounded-l-full border border-white/40 bg-white/70 px-4 py-2 text-sm shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent dark:border-neutral-700/60 dark:bg-neutral-900/70 dark:text-white"
+            />
+            <button
+              class="bg-primary text-white px-4 py-2 rounded-r-md hover:bg-primary-dark focus:outline-none"
+              @click="searchAssets"
             >
-              <div class="flex justify-between">
-                <div>
-                  <span class="font-medium text-neutral-900 dark:text-white">{{ result.symbol }}</span>
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+              </svg>
+            </button>
+          </div>
+
+          <div
+            v-if="searchResults.length > 0"
+            class="absolute z-10 mt-2 w-full rounded-2xl border border-white/60 bg-white/90 shadow-2xl backdrop-blur dark:border-neutral-700/60 dark:bg-neutral-900/90 max-h-60 overflow-y-auto"
+          >
+            <ul class="py-1">
+              <li
+                v-for="result in searchResults"
+                :key="result.symbol"
+                class="px-4 py-2 text-sm text-neutral-700 transition hover:bg-white dark:text-neutral-200 dark:hover:bg-neutral-800 cursor-pointer"
+                @click="selectAsset(result)"
+              >
+                <div class="flex justify-between">
+                  <div>
+                    <span class="font-medium text-neutral-900 dark:text-white">{{ result.symbol }}</span>
                   <span class="ml-2 text-sm text-neutral-500 dark:text-neutral-400">{{ result.name }}</span>
                 </div>
                 <span class="text-xs text-neutral-500 dark:text-neutral-400">{{ result.exchange }}</span>
@@ -46,13 +51,15 @@
       </div>
     </div>
 
-    <div v-if="currentAsset">
-      <div class="mb-6 flex flex-col md:flex-row md:items-center md:justify-between">
-        <div>
-          <div class="flex items-center">
-            <h2 class="text-xl font-bold text-neutral-900 dark:text-white">{{ currentAsset.symbol }}</h2>
-            <span class="ml-2 text-sm text-neutral-500 dark:text-neutral-400">{{ currentAsset.name }}</span>
-            <button @click="toggleFavorite" class="ml-2 text-neutral-400 hover:text-yellow-500 focus:outline-none">
+      </div>
+
+      <div v-if="currentAsset" class="space-y-6">
+        <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <div class="flex items-center">
+              <h2 class="text-xl font-bold text-neutral-900 dark:text-white">{{ currentAsset.symbol }}</h2>
+              <span class="ml-2 text-sm text-neutral-500 dark:text-neutral-400">{{ currentAsset.name }}</span>
+              <button @click="toggleFavorite" class="ml-2 text-neutral-400 hover:text-yellow-500 focus:outline-none">
               <svg v-if="isFavorite" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-yellow-500" viewBox="0 0 20 20" fill="currentColor">
                 <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
               </svg>
@@ -71,40 +78,40 @@
             {{ formatChange(priceChange, priceChangePercent) }}
           </p>
         </div>
-      </div>
+        </div>
 
-      <div class="border-b border-neutral-200 dark:border-neutral-700 mb-6">
-        <nav class="-mb-px flex space-x-8">
-          <button
-            @click="activeTab = 'chart'"
-            class="py-4 px-1 border-b-2 font-medium text-sm focus:outline-none"
-            :class="activeTab === 'chart' ? 'border-primary text-primary' : 'border-transparent text-neutral-500 hover:text-neutral-700 hover:border-neutral-300 dark:text-neutral-400 dark:hover:text-neutral-300'"
-          >
-            Graphique
-          </button>
-          <button
-            @click="activeTab = 'indicators'"
-            class="py-4 px-1 border-b-2 font-medium text-sm focus:outline-none"
-            :class="activeTab === 'indicators' ? 'border-primary text-primary' : 'border-transparent text-neutral-500 hover:text-neutral-700 hover:border-neutral-300 dark:text-neutral-400 dark:hover:text-neutral-300'"
-          >
-            Indicateurs
-          </button>
-          <button
-            @click="activeTab = 'ict'"
-            class="py-4 px-1 border-b-2 font-medium text-sm focus:outline-none"
-            :class="activeTab === 'ict' ? 'border-primary text-primary' : 'border-transparent text-neutral-500 hover:text-neutral-700 hover:border-neutral-300 dark:text-neutral-400 dark:hover:text-neutral-300'"
-          >
-            ICT
-          </button>
-          <button
-            @click="activeTab = 'overview'"
-            class="py-4 px-1 border-b-2 font-medium text-sm focus:outline-none"
-            :class="activeTab === 'overview' ? 'border-primary text-primary' : 'border-transparent text-neutral-500 hover:text-neutral-700 hover:border-neutral-300 dark:text-neutral-400 dark:hover:text-neutral-300'"
-          >
-            Aperçu
-          </button>
-        </nav>
-      </div>
+        <div class="border-b border-white/40 dark:border-neutral-700/60">
+          <nav class="-mb-px flex flex-wrap gap-4">
+            <button
+              @click="activeTab = 'chart'"
+              class="rounded-full px-4 py-2 text-sm font-medium transition"
+              :class="activeTab === 'chart' ? 'bg-primary text-white shadow' : 'bg-white/70 text-neutral-600 hover:bg-white dark:bg-neutral-900/70 dark:text-neutral-300 dark:hover:bg-neutral-800'"
+            >
+              Graphique
+            </button>
+            <button
+              @click="activeTab = 'indicators'"
+              class="rounded-full px-4 py-2 text-sm font-medium transition"
+              :class="activeTab === 'indicators' ? 'bg-primary text-white shadow' : 'bg-white/70 text-neutral-600 hover:bg-white dark:bg-neutral-900/70 dark:text-neutral-300 dark:hover:bg-neutral-800'"
+            >
+              Indicateurs
+            </button>
+            <button
+              @click="activeTab = 'ict'"
+              class="rounded-full px-4 py-2 text-sm font-medium transition"
+              :class="activeTab === 'ict' ? 'bg-primary text-white shadow' : 'bg-white/70 text-neutral-600 hover:bg-white dark:bg-neutral-900/70 dark:text-neutral-300 dark:hover:bg-neutral-800'"
+            >
+              ICT
+            </button>
+            <button
+              @click="activeTab = 'overview'"
+              class="rounded-full px-4 py-2 text-sm font-medium transition"
+              :class="activeTab === 'overview' ? 'bg-primary text-white shadow' : 'bg-white/70 text-neutral-600 hover:bg-white dark:bg-neutral-900/70 dark:text-neutral-300 dark:hover:bg-neutral-800'"
+            >
+              Aperçu
+            </button>
+          </nav>
+        </div>
 
       <div>
         <div v-if="activeTab === 'chart'" class="mb-6">
@@ -322,6 +329,7 @@
 <script>
 import { ref, reactive, computed, watch, onMounted, nextTick } from 'vue'
 import { useToast } from 'vue-toastification'
+import PageHeader from '@/components/layout/PageHeader.vue'
 
 const MOCK_ASSETS = [
   { symbol: 'AAPL', name: 'Apple Inc.', exchange: 'NASDAQ', currency: 'USD' },
@@ -341,6 +349,9 @@ const DEFAULT_ASSET = {
 
 export default {
   name: 'TechnicalAnalysis',
+  components: {
+    PageHeader
+  },
   setup() {
     const toast = useToast()
 


### PR DESCRIPTION
## Summary
- add a glassmorphism-inspired design system in Tailwind with reusable glass cards, page shells, and auth layouts
- refresh the app/header/footer shells and introduce a reusable PageHeader component to unify hero sections
- restyle the dashboard, alerts, calendar, portfolio, settings, technical analysis, login, and registration views with the new design language

## Testing
- npm run lint *(fails: existing ESLint setup cannot parse Vue SFC templates)*

------
https://chatgpt.com/codex/tasks/task_e_68dfed6a548883229705f72c61d7237e