### PR TITLE
feat: refactor navigation layout and theme handling

### DIFF
--- a/finance-app/frontend/src/App.vue
+++ b/finance-app/frontend/src/App.vue
@@ -6,15 +6,23 @@
       <div class="absolute bottom-0 right-12 h-64 w-64 rounded-full bg-secondary/20 blur-3xl dark:bg-secondary/15"></div>
     </div>
 
-    <header-component v-if="isAuthenticated" />
-    <main class="page-container">
-      <router-view v-slot="{ Component }">
-        <transition name="page" mode="out-in">
-          <component :is="Component" />
-        </transition>
-      </router-view>
-    </main>
-    <footer-component v-if="isAuthenticated" />
+    <div class="relative flex min-h-screen">
+      <sidebar-navigation v-if="isAuthenticated" />
+
+      <div class="flex min-h-screen flex-1 flex-col">
+        <header-component v-if="isAuthenticated" />
+        <main :class="mainClasses">
+          <router-view v-slot="{ Component }">
+            <transition name="page" mode="out-in">
+              <component :is="Component" />
+            </transition>
+          </router-view>
+        </main>
+        <footer-component v-if="isAuthenticated" />
+      </div>
+    </div>
+
+    <mobile-bottom-nav v-if="isAuthenticated" />
   </div>
 </template>
 
@@ -23,19 +31,29 @@ import { computed } from 'vue'
 import { useStore } from 'vuex'
 import HeaderComponent from './components/layout/HeaderComponent.vue'
 import FooterComponent from './components/layout/FooterComponent.vue'
+import SidebarNavigation from './components/layout/SidebarNavigation.vue'
+import MobileBottomNav from './components/layout/MobileBottomNav.vue'
 
 export default {
   name: 'App',
   components: {
     HeaderComponent,
-    FooterComponent
+    FooterComponent,
+    SidebarNavigation,
+    MobileBottomNav
   },
   setup() {
     const store = useStore()
     const isAuthenticated = computed(() => store.getters['auth/isAuthenticated'])
 
+    const mainClasses = computed(() => [
+      'page-container flex-1',
+      isAuthenticated.value ? 'pb-32 lg:pb-16 xl:pb-20' : ''
+    ])
+
     return {
-      isAuthenticated
+      isAuthenticated,
+      mainClasses
     }
   }
 }

--- a/finance-app/frontend/src/components/layout/HeaderComponent.vue
+++ b/finance-app/frontend/src/components/layout/HeaderComponent.vue
@@ -1,36 +1,28 @@
 <template>
   <header class="relative z-20">
-    <nav class="glass-panel mx-auto mt-6 w-[calc(100%-2rem)] max-w-7xl rounded-3xl px-4 py-3 sm:px-6 lg:px-8">
-      <div class="flex h-16 items-center justify-between">
-        <div class="flex items-center gap-6">
-          <router-link to="/dashboard" class="flex items-center text-xl font-semibold tracking-tight text-neutral-900 transition hover:text-primary dark:text-white">
-            <span class="mr-2 inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-primary/15 text-primary">
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-5 w-5">
-                <path d="M12 3a9 9 0 00-9 9v5.5A3.5 3.5 0 006.5 21h11a3.5 3.5 0 003.5-3.5V12a9 9 0 00-9-9zm0 2a7 7 0 017 7v5.5c0 .828-.672 1.5-1.5 1.5h-11A1.5 1.5 0 015 17.5V12a7 7 0 017-7zm0 4a3 3 0 00-3 3v2a3 3 0 006 0v-2a3 3 0 00-3-3zm0 2a1 1 0 011 1v2a1 1 0 11-2 0v-2a1 1 0 011-1z" />
-              </svg>
-            </span>
-            Finance Analysis
-          </router-link>
-
-          <div class="hidden items-center gap-1 rounded-full bg-white/60 px-1 py-1 text-sm font-medium dark:bg-neutral-800/80 md:flex">
-            <router-link
-              v-for="item in navigation"
-              :key="item.route"
-              :to="item.to"
-              class="inline-flex items-center rounded-full px-4 py-2 transition"
-              :class="isActive(item.route)
-                ? 'bg-primary text-white shadow-sm'
-                : 'text-neutral-500 hover:text-neutral-900 hover:bg-white dark:text-neutral-300 dark:hover:text-white dark:hover:bg-neutral-700/70'"
-            >
-              {{ item.label }}
-            </router-link>
+    <div class="glass-panel mx-auto mt-6 w-[calc(100%-2rem)] max-w-7xl rounded-3xl px-4 py-4 sm:px-6 lg:px-8">
+      <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div class="flex items-center gap-4">
+          <div class="inline-flex h-12 w-12 items-center justify-center rounded-3xl bg-primary/10 text-primary">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="h-6 w-6">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M3 4h7l2 3h9v11a2 2 0 01-2 2H5a2 2 0 01-2-2V4z" />
+            </svg>
+          </div>
+          <div>
+            <p class="text-sm font-medium uppercase tracking-[0.3em] text-neutral-400 dark:text-neutral-500">Vue d'ensemble</p>
+            <h2 class="text-xl font-semibold text-neutral-900 dark:text-white">
+              Bonjour {{ greetingName }}
+            </h2>
+            <p class="text-sm text-neutral-500 dark:text-neutral-400">
+              Suivez vos marchés, alertes et portefeuilles en temps réel.
+            </p>
           </div>
         </div>
 
-        <div class="hidden items-center gap-4 md:flex">
+        <div class="flex items-center gap-3">
           <button
             @click="toggleDarkMode"
-            class="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/60 bg-white/80 text-neutral-500 transition hover:text-primary dark:border-neutral-700/70 dark:bg-neutral-800/80 dark:text-neutral-300 dark:hover:text-primary"
+            class="inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/60 bg-white/80 text-neutral-500 transition hover:text-primary dark:border-neutral-700/70 dark:bg-neutral-800/80 dark:text-neutral-300 dark:hover:text-primary"
           >
             <span class="sr-only">Changer de thème</span>
             <svg v-if="isDarkMode" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -46,169 +38,79 @@
               @click="toggleUserMenu"
               class="flex items-center gap-3 rounded-full border border-white/60 bg-white/80 py-1 pl-1 pr-4 text-sm font-medium text-neutral-700 shadow-sm transition hover:text-primary dark:border-neutral-700/70 dark:bg-neutral-800/80 dark:text-neutral-200"
             >
-              <span class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-primary text-white">
+              <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-primary text-white">
                 {{ userInitials }}
               </span>
-              <span class="hidden lg:block">{{ user.full_name || 'Utilisateur' }}</span>
+              <span class="hidden sm:block">{{ user.full_name || 'Utilisateur' }}</span>
               <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
               </svg>
             </button>
             <div
               v-if="userMenuOpen"
-              class="glass-panel absolute right-0 mt-3 w-56 overflow-hidden rounded-2xl p-2 text-sm shadow-2xl"
+              class="glass-panel absolute right-0 mt-3 w-60 overflow-hidden rounded-2xl p-3 text-sm shadow-2xl"
             >
-              <div class="px-3 py-2 text-xs uppercase tracking-wide text-neutral-400 dark:text-neutral-500">
-                Accès rapide
+              <div class="flex items-center gap-3 rounded-2xl bg-white/60 p-3 dark:bg-neutral-800/60">
+                <div class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-primary/15 text-primary">
+                  {{ userInitials }}
+                </div>
+                <div>
+                  <p class="text-sm font-semibold text-neutral-900 dark:text-white">{{ user.full_name }}</p>
+                  <p class="text-xs text-neutral-500 dark:text-neutral-400">{{ user.email }}</p>
+                </div>
               </div>
-              <router-link
-                to="/settings"
-                class="flex items-center gap-3 rounded-xl px-3 py-2 text-neutral-600 transition hover:bg-white/70 hover:text-neutral-900 dark:text-neutral-300 dark:hover:bg-neutral-700/80 dark:hover:text-white"
-                @click="userMenuOpen = false"
-              >
-                <span class="inline-flex h-8 w-8 items-center justify-center rounded-xl bg-primary/15 text-primary">
-                  <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 11V7a4 4 0 118 0v4m-2 4h-4m0 0v4m0-4h4m-4 0H7" />
-                  </svg>
-                </span>
-                Paramètres
-              </router-link>
-              <button
-                @click.prevent="logout"
-                class="flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left text-neutral-600 transition hover:bg-danger/10 hover:text-danger dark:text-neutral-300 dark:hover:bg-danger/15 dark:hover:text-danger"
-              >
-                <span class="inline-flex h-8 w-8 items-center justify-center rounded-xl bg-danger/10 text-danger">
-                  <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7" />
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 8v8" />
-                  </svg>
-                </span>
-                Déconnexion
-              </button>
-            </div>
-          </div>
-        </div>
-
-        <div class="flex items-center gap-3 md:hidden">
-          <button
-            @click="toggleDarkMode"
-            class="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/60 bg-white/80 text-neutral-500 transition hover:text-primary dark:border-neutral-700/70 dark:bg-neutral-800/80 dark:text-neutral-300 dark:hover:text-primary"
-          >
-            <span class="sr-only">Changer de thème</span>
-            <svg v-if="isDarkMode" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
-            </svg>
-            <svg v-else xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
-            </svg>
-          </button>
-          <button
-            @click="toggleMobileMenu"
-            class="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/60 bg-white/80 text-neutral-500 transition hover:text-primary dark:border-neutral-700/70 dark:bg-neutral-800/80 dark:text-neutral-300 dark:hover:text-primary"
-          >
-            <span class="sr-only">Ouvrir le menu principal</span>
-            <svg
-              :class="{ hidden: mobileMenuOpen, block: !mobileMenuOpen }"
-              class="h-5 w-5"
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              aria-hidden="true"
-            >
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-            </svg>
-            <svg
-              :class="{ block: mobileMenuOpen, hidden: !mobileMenuOpen }"
-              class="h-5 w-5"
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              aria-hidden="true"
-            >
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
-        </div>
-      </div>
-
-      <div
-        :class="{ 'max-h-[460px] opacity-100': mobileMenuOpen, 'max-h-0 opacity-0': !mobileMenuOpen }"
-        class="md:hidden overflow-hidden transition-all duration-300 ease-in-out"
-      >
-        <div class="mt-4 space-y-2 rounded-2xl bg-white/80 p-3 shadow-inner dark:bg-neutral-900/80">
-          <router-link
-            v-for="item in navigation"
-            :key="item.route"
-            :to="item.to"
-            class="block rounded-xl px-4 py-3 text-sm font-medium transition"
-            :class="isActive(item.route)
-              ? 'bg-primary/10 text-primary'
-              : 'text-neutral-600 hover:bg-white hover:text-neutral-900 dark:text-neutral-300 dark:hover:bg-neutral-800'"
-            @click="mobileMenuOpen = false"
-          >
-            {{ item.label }}
-          </router-link>
-          <div class="rounded-2xl bg-white/70 p-4 text-sm dark:bg-neutral-900/70">
-            <div class="flex items-center gap-3">
-              <div class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-primary text-white">
-                {{ userInitials }}
+              <div class="mt-3 grid gap-2">
+                <router-link
+                  to="/settings"
+                  class="flex items-center gap-3 rounded-xl px-3 py-2 text-neutral-600 transition hover:bg-white/70 hover:text-neutral-900 dark:text-neutral-300 dark:hover:bg-neutral-700/70 dark:hover:text-white"
+                  @click="userMenuOpen = false"
+                >
+                  <span class="inline-flex h-8 w-8 items-center justify-center rounded-xl bg-primary/15 text-primary">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 11V7a4 4 0 118 0v4m-2 4h-4m0 0v4m0-4h4m-4 0H7" />
+                    </svg>
+                  </span>
+                  Paramètres
+                </router-link>
+                <button
+                  @click.prevent="logout"
+                  class="flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left text-neutral-600 transition hover:bg-danger/10 hover:text-danger dark:text-neutral-300 dark:hover:bg-danger/15 dark:hover:text-danger"
+                >
+                  <span class="inline-flex h-8 w-8 items-center justify-center rounded-xl bg-danger/10 text-danger">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7" />
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 8v8" />
+                    </svg>
+                  </span>
+                  Déconnexion
+                </button>
               </div>
-              <div class="text-sm">
-                <p class="font-semibold text-neutral-900 dark:text-white">{{ user.full_name }}</p>
-                <p class="text-neutral-500 dark:text-neutral-400">{{ user.email }}</p>
-              </div>
-            </div>
-            <div class="mt-4 grid gap-2">
-              <router-link
-                to="/settings"
-                class="rounded-xl px-3 py-2 text-neutral-600 transition hover:bg-white hover:text-neutral-900 dark:text-neutral-300 dark:hover:bg-neutral-800"
-                @click="mobileMenuOpen = false"
-              >
-                Paramètres
-              </router-link>
-              <button
-                @click.prevent="logout"
-                class="rounded-xl px-3 py-2 text-left text-neutral-600 transition hover:bg-danger/10 hover:text-danger dark:text-neutral-300 dark:hover:bg-danger/15 dark:hover:text-danger"
-              >
-                Déconnexion
-              </button>
             </div>
           </div>
         </div>
       </div>
-    </nav>
+    </div>
   </header>
 </template>
 
 <script>
 import { ref, computed } from 'vue'
 import { useStore } from 'vuex'
-import { useRouter, useRoute } from 'vue-router'
+import { useRouter } from 'vue-router'
 import { useToast } from 'vue-toastification'
+import { useTheme } from '@/composables/useTheme'
 
 export default {
   name: 'HeaderComponent',
   setup() {
     const store = useStore()
     const router = useRouter()
-    const route = useRoute()
     const toast = useToast()
 
-    const mobileMenuOpen = ref(false)
     const userMenuOpen = ref(false)
 
-    const navigation = [
-      { label: 'Tableau de bord', route: 'dashboard', to: '/dashboard' },
-      { label: 'Analyse', route: 'analysis', to: '/analysis/technical' },
-      { label: 'Portefeuille', route: 'portfolio', to: '/portfolio' },
-      { label: 'Alertes', route: 'alerts', to: '/alerts' },
-      { label: 'Calendrier', route: 'calendar', to: '/calendar' }
-    ]
-
     const user = computed(() => store.getters['auth/getUser'] || {})
-    const isDarkMode = computed(() => store.getters.isDarkMode)
+    const { isDarkMode, toggleTheme, initializeTheme } = useTheme()
 
     const userInitials = computed(() => {
       if (!user.value || !user.value.full_name) return '?'
@@ -220,26 +122,22 @@ export default {
         .substring(0, 2)
     })
 
-    const toggleMobileMenu = () => {
-      mobileMenuOpen.value = !mobileMenuOpen.value
-    }
+    const greetingName = computed(() => {
+      if (user.value?.full_name) {
+        return user.value.full_name.split(' ')[0]
+      }
+      if (user.value?.first_name) {
+        return user.value.first_name
+      }
+      return 'investisseur'
+    })
 
     const toggleUserMenu = () => {
       userMenuOpen.value = !userMenuOpen.value
     }
 
     const toggleDarkMode = () => {
-      store.dispatch('toggleDarkMode')
-      // Appliquer la classe dark au document
-      if (store.getters.isDarkMode) {
-        document.documentElement.classList.add('dark')
-      } else {
-        document.documentElement.classList.remove('dark')
-      }
-    }
-
-    const isActive = (routeName) => {
-      return route.path.includes(routeName)
+      toggleTheme()
     }
 
     const logout = async () => {
@@ -252,22 +150,16 @@ export default {
       }
     }
 
-    // Appliquer le thème au chargement
-    if (isDarkMode.value) {
-      document.documentElement.classList.add('dark')
-    }
+    initializeTheme()
 
     return {
-      mobileMenuOpen,
       userMenuOpen,
       user,
       isDarkMode,
       userInitials,
-      navigation,
-      toggleMobileMenu,
+      greetingName,
       toggleUserMenu,
       toggleDarkMode,
-      isActive,
       logout
     }
   }

--- a/finance-app/frontend/src/components/layout/MobileBottomNav.vue
+++ b/finance-app/frontend/src/components/layout/MobileBottomNav.vue
@@ -1,0 +1,62 @@
+<template>
+  <nav
+    class="pointer-events-auto lg:hidden"
+    aria-label="Navigation principale mobile"
+  >
+    <div class="fixed inset-x-0 bottom-0 z-30 flex justify-center px-4 pb-safe">
+      <div class="flex w-full max-w-md items-center justify-between rounded-3xl border border-white/60 bg-white/90 px-4 py-3 text-xs font-medium shadow-2xl backdrop-blur-xl dark:border-neutral-700/70 dark:bg-neutral-900/90">
+        <router-link
+          v-for="item in navigation"
+          :key="item.to"
+          :to="item.to"
+          class="flex flex-1 flex-col items-center gap-1 rounded-2xl px-2 py-2 transition"
+          :aria-label="item.label"
+          :class="isActive(item.match)
+            ? 'text-primary'
+            : 'text-neutral-500 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-white'"
+        >
+          <span
+            class="flex h-10 w-10 items-center justify-center rounded-2xl"
+            :class="isActive(item.match)
+              ? 'bg-primary/15 text-primary'
+              : 'bg-white/60 text-neutral-500 dark:bg-neutral-800/80 dark:text-neutral-300'"
+            aria-hidden="true"
+          >
+            <navigation-icon :name="item.icon" icon-class="h-5 w-5" />
+          </span>
+          <span class="text-[11px] leading-tight">{{ item.label }}</span>
+        </router-link>
+      </div>
+    </div>
+  </nav>
+</template>
+
+<script>
+import { useRoute } from 'vue-router'
+import NavigationIcon from './NavigationIcon.vue'
+import { mainNavigation } from '../../constants/navigation'
+
+export default {
+  name: 'MobileBottomNav',
+  components: {
+    NavigationIcon
+  },
+  setup() {
+    const route = useRoute()
+    const navigation = mainNavigation
+
+    const isActive = (match) => route.path.startsWith(match)
+
+    return {
+      navigation,
+      isActive
+    }
+  }
+}
+</script>
+
+<style scoped>
+.pb-safe {
+  padding-bottom: calc(1rem + env(safe-area-inset-bottom, 0px));
+}
+</style>

--- a/finance-app/frontend/src/components/layout/NavigationIcon.vue
+++ b/finance-app/frontend/src/components/layout/NavigationIcon.vue
@@ -1,0 +1,127 @@
+<template>
+  <svg
+    v-if="name === 'dashboard'"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="1.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    :class="iconClass"
+    aria-hidden="true"
+  >
+    <path d="M3 12l9-9 9 9" />
+    <path d="M9 21V9h6v12" />
+  </svg>
+  <svg
+    v-else-if="name === 'analysis'"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="1.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    :class="iconClass"
+    aria-hidden="true"
+  >
+    <path d="M3 3v18h18" />
+    <path d="M7 14l3-3 4 4 6-6" />
+  </svg>
+  <svg
+    v-else-if="name === 'portfolio'"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="1.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    :class="iconClass"
+    aria-hidden="true"
+  >
+    <path d="M3 7h18v10a4 4 0 01-4 4H7a4 4 0 01-4-4V7z" />
+    <path d="M9 7V5a3 3 0 016 0v2" />
+  </svg>
+  <svg
+    v-else-if="name === 'alerts'"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="1.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    :class="iconClass"
+    aria-hidden="true"
+  >
+    <path d="M12 22a2 2 0 002-2H10a2 2 0 002 2z" />
+    <path d="M18 16v-5a6 6 0 10-12 0v5l-1.5 2h15z" />
+  </svg>
+  <svg
+    v-else-if="name === 'calendar'"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="1.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    :class="iconClass"
+    aria-hidden="true"
+  >
+    <path d="M4 5h16a1 1 0 011 1v14a1 1 0 01-1 1H4a1 1 0 01-1-1V6a1 1 0 011-1z" />
+    <path d="M8 3v4" />
+    <path d="M16 3v4" />
+    <path d="M3 11h18" />
+  </svg>
+  <svg
+    v-else-if="name === 'settings'"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="1.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    :class="iconClass"
+    aria-hidden="true"
+  >
+    <path
+      d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 01-2.83 2.83l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09a1.65 1.65 0 00-1-1.51 1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06a1.65 1.65 0 00.33-1.82 1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09a1.65 1.65 0 001.51-1 1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06a1.65 1.65 0 001.82.33H9a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51h.09a1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06a1.65 1.65 0 00-.33 1.82V9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z"
+    />
+    <circle cx="12" cy="12" r="3" />
+  </svg>
+  <svg
+    v-else
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="1.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    :class="iconClass"
+    aria-hidden="true"
+  >
+    <circle cx="12" cy="12" r="9" />
+    <path d="M12 8v4l3 3" />
+  </svg>
+</template>
+
+<script>
+export default {
+  name: 'NavigationIcon',
+  props: {
+    name: {
+      type: String,
+      required: true
+    },
+    iconClass: {
+      type: String,
+      default: ''
+    }
+  }
+}
+</script>

--- a/finance-app/frontend/src/components/layout/SidebarNavigation.vue
+++ b/finance-app/frontend/src/components/layout/SidebarNavigation.vue
@@ -1,0 +1,172 @@
+<template>
+  <aside
+    class="sidebar"
+    :class="[
+      isCollapsed ? 'sidebar--collapsed' : '',
+      'hidden lg:sticky lg:top-0 lg:flex lg:h-screen lg:flex-col lg:justify-between'
+    ]"
+  >
+    <div>
+      <div class="flex items-center justify-between px-5 pt-6">
+        <router-link to="/dashboard" class="flex items-center gap-3 text-left">
+          <span
+            class="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-primary/20 text-primary"
+            aria-hidden="true"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-5 w-5">
+              <path
+                d="M12 3a9 9 0 00-9 9v5.5A3.5 3.5 0 006.5 21h11a3.5 3.5 0 003.5-3.5V12a9 9 0 00-9-9zm0 2a7 7 0 017 7v5.5c0 .828-.672 1.5-1.5 1.5h-11A1.5 1.5 0 015 17.5V12a7 7 0 017-7zm0 4a3 3 0 00-3 3v2a3 3 0 006 0v-2a3 3 0 00-3-3zm0 2a1 1 0 011 1v2a1 1 0 11-2 0v-2a1 1 0 011-1z"
+              />
+            </svg>
+          </span>
+          <div v-if="!isCollapsed" class="flex flex-col">
+            <span class="text-base font-semibold text-neutral-900 dark:text-white">Finance Analysis</span>
+            <span class="text-xs font-medium text-neutral-500 dark:text-neutral-400">Plateforme d'analyses</span>
+          </div>
+        </router-link>
+        <button
+          type="button"
+          class="inline-flex h-10 w-10 items-center justify-center rounded-2xl border border-white/50 bg-white/80 text-neutral-500 transition hover:text-primary dark:border-neutral-700/60 dark:bg-neutral-900/70 dark:text-neutral-300"
+          @click="toggleSidebar"
+        >
+          <span class="sr-only">Basculer la navigation</span>
+          <svg v-if="isCollapsed" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="h-5 w-5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M15 6l-6 6 6 6" />
+          </svg>
+          <svg v-else xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="h-5 w-5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M9 6l6 6-6 6" />
+          </svg>
+        </button>
+      </div>
+
+      <nav class="mt-8 space-y-2 px-3">
+        <router-link
+          v-for="item in navigation"
+          :key="item.to"
+          :to="item.to"
+          class="group flex items-center gap-3 rounded-2xl px-4 py-3 text-sm font-medium transition"
+          :class="isActive(item.match)
+            ? 'bg-primary text-white shadow-lg'
+            : 'text-neutral-600 hover:bg-white/90 hover:text-neutral-900 dark:text-neutral-300 dark:hover:bg-neutral-800/80 dark:hover:text-white'"
+        >
+          <span class="flex h-10 w-10 items-center justify-center rounded-xl bg-white/70 text-primary shadow-sm transition group-hover:bg-white dark:bg-neutral-900/60 dark:text-primary">
+            <navigation-icon :name="item.icon" icon-class="h-5 w-5" />
+          </span>
+          <div v-if="!isCollapsed" class="flex flex-col">
+            <span>{{ item.label }}</span>
+            <span class="text-xs font-normal text-neutral-500 opacity-0 transition group-hover:opacity-100 dark:text-neutral-400">
+              {{ item.description }}
+            </span>
+          </div>
+        </router-link>
+      </nav>
+    </div>
+
+    <div class="px-5 pb-8">
+      <div
+        class="rounded-2xl border border-white/50 bg-white/80 p-4 text-sm shadow-inner backdrop-blur-lg dark:border-neutral-700/60 dark:bg-neutral-900/70"
+      >
+        <h2 class="text-xs font-semibold uppercase tracking-[0.3em] text-neutral-400 dark:text-neutral-500" v-if="!isCollapsed">
+          Conseils rapides
+        </h2>
+        <p class="mt-1 text-neutral-600 dark:text-neutral-300" v-if="!isCollapsed">
+          Personnalisez votre tableau de bord en ajoutant des widgets depuis l'écran d'analyse.
+        </p>
+        <router-link
+          v-if="!isCollapsed"
+          to="/settings"
+          class="mt-4 inline-flex items-center gap-2 text-xs font-medium text-primary hover:text-primary-dark"
+        >
+          Gérer mes préférences
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="h-4 w-4">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M5 12h14M12 5l7 7-7 7" />
+          </svg>
+        </router-link>
+        <button
+          v-else
+          @click="toggleSidebar"
+          class="mt-1 inline-flex items-center justify-center rounded-lg px-3 py-1 text-xs font-medium text-primary hover:text-primary-dark"
+        >
+          Ouvrir
+        </button>
+      </div>
+    </div>
+  </aside>
+</template>
+
+<script>
+import { ref, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
+import NavigationIcon from './NavigationIcon.vue'
+import { mainNavigation } from '../../constants/navigation'
+
+const STORAGE_KEY = 'sidebar-collapsed'
+
+export default {
+  name: 'SidebarNavigation',
+  components: {
+    NavigationIcon
+  },
+  setup() {
+    const route = useRoute()
+    const navigation = mainNavigation
+    const isCollapsed = ref(false)
+
+    const initializeState = () => {
+      if (typeof window === 'undefined') return
+      const stored = localStorage.getItem(STORAGE_KEY)
+      isCollapsed.value = stored === 'true'
+    }
+
+    const toggleSidebar = () => {
+      isCollapsed.value = !isCollapsed.value
+      if (typeof window !== 'undefined') {
+        localStorage.setItem(STORAGE_KEY, String(isCollapsed.value))
+      }
+    }
+
+    const isActive = (match) => {
+      return route.path.startsWith(match)
+    }
+
+    onMounted(() => {
+      initializeState()
+    })
+
+    return {
+      navigation,
+      isCollapsed,
+      isActive,
+      toggleSidebar
+    }
+  }
+}
+</script>
+
+<style scoped>
+.sidebar {
+  @apply relative z-20 bg-white/80 shadow-2xl backdrop-blur-xl transition-all duration-300 ease-in-out dark:bg-neutral-900/80 dark:shadow-none;
+  width: 280px;
+}
+
+.sidebar--collapsed {
+  width: 110px;
+}
+
+.sidebar::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 0 32px 32px 0;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  pointer-events: none;
+}
+
+.dark .sidebar::before {
+  border-color: rgba(82, 82, 91, 0.6);
+}
+
+.sidebar--collapsed::before {
+  border-radius: 0 28px 28px 0;
+}
+</style>

--- a/finance-app/frontend/src/composables/useTheme.js
+++ b/finance-app/frontend/src/composables/useTheme.js
@@ -1,0 +1,64 @@
+import { ref, onMounted } from 'vue'
+
+const THEME_STORAGE_KEY = 'theme'
+const isDarkMode = ref(false)
+let isInitialized = false
+
+const applyTheme = (dark) => {
+  if (typeof document === 'undefined') return
+  const root = document.documentElement
+
+  if (dark) {
+    root.classList.add('dark')
+    localStorage.setItem(THEME_STORAGE_KEY, 'dark')
+  } else {
+    root.classList.remove('dark')
+    localStorage.setItem(THEME_STORAGE_KEY, 'light')
+  }
+}
+
+const detectInitialTheme = () => {
+  if (typeof window === 'undefined') return false
+
+  const stored = localStorage.getItem(THEME_STORAGE_KEY)
+  if (stored) {
+    return stored === 'dark'
+  }
+
+  if (window.matchMedia) {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches
+  }
+
+  return false
+}
+
+const initializeTheme = () => {
+  if (isInitialized) return
+  const dark = detectInitialTheme()
+  isDarkMode.value = dark
+  applyTheme(dark)
+  isInitialized = true
+}
+
+export const useTheme = () => {
+  onMounted(() => {
+    initializeTheme()
+  })
+
+  const toggleTheme = () => {
+    isDarkMode.value = !isDarkMode.value
+    applyTheme(isDarkMode.value)
+  }
+
+  const setTheme = (dark) => {
+    isDarkMode.value = dark
+    applyTheme(dark)
+  }
+
+  return {
+    isDarkMode,
+    toggleTheme,
+    setTheme,
+    initializeTheme
+  }
+}

--- a/finance-app/frontend/src/constants/navigation.js
+++ b/finance-app/frontend/src/constants/navigation.js
@@ -1,0 +1,44 @@
+export const mainNavigation = [
+  {
+    label: 'Tableau de bord',
+    description: "Vue d'ensemble personnalisable",
+    to: '/dashboard',
+    match: '/dashboard',
+    icon: 'dashboard'
+  },
+  {
+    label: 'Analyse',
+    description: "Outils d'analyse technique et fondamentale",
+    to: '/analysis/technical',
+    match: '/analysis',
+    icon: 'analysis'
+  },
+  {
+    label: 'Portefeuille',
+    description: 'Gestion des actifs et suivi des performances',
+    to: '/portfolio',
+    match: '/portfolio',
+    icon: 'portfolio'
+  },
+  {
+    label: 'Alertes',
+    description: 'Configuration et historique des alertes',
+    to: '/alerts',
+    match: '/alerts',
+    icon: 'alerts'
+  },
+  {
+    label: 'Calendrier',
+    description: 'Événements financiers à venir',
+    to: '/calendar',
+    match: '/calendar',
+    icon: 'calendar'
+  },
+  {
+    label: 'Paramètres',
+    description: "Configuration de l'application et du profil",
+    to: '/settings',
+    match: '/settings',
+    icon: 'settings'
+  }
+]

--- a/finance-app/frontend/src/views/Settings.vue
+++ b/finance-app/frontend/src/views/Settings.vue
@@ -344,6 +344,7 @@ import { ref, computed, onMounted } from 'vue'
 import { useStore } from 'vuex'
 import { useToast } from 'vue-toastification'
 import PageHeader from '@/components/layout/PageHeader.vue'
+import { useTheme } from '@/composables/useTheme'
 
 const PREFERENCES_KEY = 'finance-app-preferences'
 
@@ -380,7 +381,7 @@ export default {
       whatsapp_number: ''
     })
 
-    const isDarkMode = ref(false)
+    const { isDarkMode, toggleTheme, initializeTheme } = useTheme()
     const showDeleteAccountModal = ref(false)
 
     const user = computed(() => store.getters['auth/getUser'])
@@ -447,23 +448,6 @@ export default {
       }
     }
 
-    const initializeTheme = () => {
-      const storedTheme = localStorage.getItem('theme')
-      isDarkMode.value = storedTheme === 'dark' || document.documentElement.classList.contains('dark')
-      applyTheme()
-    }
-
-    const applyTheme = () => {
-      const root = document.documentElement
-      if (isDarkMode.value) {
-        root.classList.add('dark')
-        localStorage.setItem('theme', 'dark')
-      } else {
-        root.classList.remove('dark')
-        localStorage.setItem('theme', 'light')
-      }
-    }
-
     const updateProfile = async () => {
       try {
         store.dispatch('setLoading', true)
@@ -502,8 +486,7 @@ export default {
     }
 
     const toggleDarkMode = () => {
-      isDarkMode.value = !isDarkMode.value
-      applyTheme()
+      toggleTheme()
     }
 
     const savePreferences = () => {


### PR DESCRIPTION
## Summary
- introduce a responsive layout with a collapsible sidebar on desktop and a bottom navigation bar on mobile
- add shared navigation configuration and icon component to keep navigation links consistent across the app
- centralize theme management with a reusable composable and update settings and header to use it

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dff97a53fc832286c62b5d9185f690